### PR TITLE
Use inset threshold for keyboard detection

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import ClueList from '@/components/ClueList'
 import { generateDaily } from '@/lib/puzzle'
 import { loadDemoFromFile } from '@/lib/puzzle'
 import { yyyyMmDd } from '@/utils/date'
+import { KEYBOARD_INSET_THRESHOLD } from '@/utils/constants'
 import { useMemo, useState, useEffect, useRef } from 'react'
 
 export default function Page() {
@@ -48,7 +49,8 @@ export default function Page() {
     if (!vv) return
     const onResize = () => {
       const inset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop)
-      setKbOpen(inset > 0)
+      const isKeyboard = inset > KEYBOARD_INSET_THRESHOLD
+      setKbOpen(isKeyboard)
       // recompute scale on each change
       requestAnimationFrame(() => {
         const inner = gridInnerRef.current

--- a/components/ClueBar.tsx
+++ b/components/ClueBar.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { KEYBOARD_INSET_THRESHOLD } from '@/utils/constants'
 
 export default function ClueBar({
   text,
@@ -18,7 +19,8 @@ export default function ClueBar({
     if (!vv) return
     const update = () => {
       const inset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop)
-      setBottom(inset)
+      const isKeyboard = inset > KEYBOARD_INSET_THRESHOLD
+      setBottom(isKeyboard ? inset : 0)
       setMaxH(Math.floor(vv.height * 0.42)) // allow up to ~42% of visible height
     }
     update()

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,0 +1,1 @@
+export const KEYBOARD_INSET_THRESHOLD = 120;


### PR DESCRIPTION
## Summary
- Guard keyboard detection using `KEYBOARD_INSET_THRESHOLD`
- Apply shared keyboard inset threshold to ClueBar positioning
- Centralize keyboard inset threshold constant

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68969ccc4c94832c9eaabc96fd7d25c8