### PR TITLE
Remove unused toggle button from crossword grid

### DIFF
--- a/components/Grid.tsx
+++ b/components/Grid.tsx
@@ -117,11 +117,8 @@ export default function Grid({
 
   return (
     <div>
-      <div className="px-4 pt-3 pb-2 text-sm text-gray-500 flex items-center justify-between">
+      <div className="px-4 pt-3 pb-2 text-sm text-gray-500 flex items-center">
         <div>Clue #{activeNumber ?? '—'} • {dir.toUpperCase()}</div>
-        {!kbOpen && (
-          <button className="underline" onClick={toggleDir}>Toggle</button>
-        )}
       </div>
       <div className="px-2">
         <div className="grid grid-cols-15 border border-gray-300 dark:border-gray-700">


### PR DESCRIPTION
## Summary
- remove Toggle button from crossword grid header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896a3de0b50832c8374f378287f6489