### PR TITLE
feat: add WebAuthn authentication routes

### DIFF
--- a/app/api/auth/webauthn-login/route.ts
+++ b/app/api/auth/webauthn-login/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+} from '@simplewebauthn/server';
+import type {
+  AuthenticationResponseJSON,
+} from '@simplewebauthn/types';
+import { getUser, upsertUser } from '@/lib/webauthn';
+
+const rpID = process.env.RP_ID || 'localhost';
+const origin = process.env.ORIGIN || `http://${rpID}:3000`;
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const username = searchParams.get('username');
+  const user = username ? getUser(username) : undefined;
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 400 });
+  }
+
+  const options = await generateAuthenticationOptions({
+    rpID,
+    allowCredentials: user.credentials.map((cred) => ({
+      id: cred.credentialID,
+      type: 'public-key',
+    })),
+  });
+  user.currentChallenge = options.challenge;
+  upsertUser(user);
+
+  return NextResponse.json(options);
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const { username, response } = body as {
+    username: string;
+    response: AuthenticationResponseJSON;
+  };
+  const user = getUser(username);
+  if (!user || !user.currentChallenge) {
+    return NextResponse.json({ error: 'User not found' }, { status: 400 });
+  }
+
+  const credID = response.rawId;
+  const dbAuthenticator = user.credentials.find(
+    (cred) => cred.credentialID === credID,
+  );
+  if (!dbAuthenticator) {
+    return NextResponse.json({ error: 'Authenticator not registered' }, { status: 400 });
+  }
+
+  let verification;
+  try {
+    verification = await verifyAuthenticationResponse({
+      response,
+      expectedChallenge: user.currentChallenge,
+      expectedOrigin: origin,
+      expectedRPID: rpID,
+      credential: {
+        id: dbAuthenticator.credentialID,
+        publicKey: dbAuthenticator.credentialPublicKey,
+        counter: dbAuthenticator.counter,
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { verified: false, error: (error as Error).message },
+      { status: 400 },
+    );
+  }
+
+  const { authenticationInfo, verified } = verification;
+  if (verified && authenticationInfo) {
+    dbAuthenticator.counter = authenticationInfo.newCounter;
+    user.currentChallenge = undefined;
+    upsertUser(user);
+  }
+
+  const res = NextResponse.json({ verified });
+  if (verified) {
+    res.cookies.set('session', user.id, {
+      httpOnly: true,
+      sameSite: 'lax',
+    });
+  }
+  return res;
+}

--- a/app/api/auth/webauthn-register/route.ts
+++ b/app/api/auth/webauthn-register/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+} from '@simplewebauthn/server';
+import type {
+  RegistrationResponseJSON,
+} from '@simplewebauthn/types';
+import { getUser, upsertUser } from '@/lib/webauthn';
+import { randomUUID } from 'crypto';
+
+const rpID = process.env.RP_ID || 'localhost';
+const origin = process.env.ORIGIN || `http://${rpID}:3000`;
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const username = searchParams.get('username');
+  if (!username) {
+    return NextResponse.json({ error: 'Missing username' }, { status: 400 });
+  }
+  let user = getUser(username);
+  if (!user) {
+    user = {
+      id: randomUUID(),
+      username,
+      credentials: [],
+    };
+    upsertUser(user);
+  }
+
+  const options = await generateRegistrationOptions({
+    rpName: 'CrossedWFriends',
+    rpID,
+    userID: Buffer.from(user.id),
+    userName: user.username,
+    attestationType: 'none',
+  });
+  user.currentChallenge = options.challenge;
+  upsertUser(user);
+
+  return NextResponse.json(options);
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const { username, response } = body as {
+    username: string;
+    response: RegistrationResponseJSON;
+  };
+  const user = getUser(username);
+  if (!user || !user.currentChallenge) {
+    return NextResponse.json({ error: 'User not found' }, { status: 400 });
+  }
+  let verification;
+  try {
+    verification = await verifyRegistrationResponse({
+      response,
+      expectedChallenge: user.currentChallenge,
+      expectedOrigin: origin,
+      expectedRPID: rpID,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { verified: false, error: (error as Error).message },
+      { status: 400 },
+    );
+  }
+
+  const { registrationInfo, verified } = verification;
+  if (verified && registrationInfo) {
+    const { credential } = registrationInfo;
+    const { id: credentialID, publicKey, counter } = credential;
+    user.credentials.push({
+      credentialID: Buffer.from(credentialID).toString('base64url'),
+      credentialPublicKey: Buffer.from(publicKey),
+      counter,
+    });
+    user.currentChallenge = undefined;
+    upsertUser(user);
+  }
+
+  return NextResponse.json({ verified });
+}

--- a/lib/webauthn.ts
+++ b/lib/webauthn.ts
@@ -1,0 +1,22 @@
+export interface Credential {
+  credentialID: string;
+  credentialPublicKey: Buffer;
+  counter: number;
+}
+
+export interface User {
+  id: string;
+  username: string;
+  credentials: Credential[];
+  currentChallenge?: string;
+}
+
+export const users = new Map<string, User>();
+
+export function getUser(username: string): User | undefined {
+  return users.get(username);
+}
+
+export function upsertUser(user: User): void {
+  users.set(user.username, user);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "cfwf-core-ui-full",
       "version": "0.2.0",
       "dependencies": {
+        "@simplewebauthn/server": "^13.1.2",
+        "@simplewebauthn/types": "^12.0.0",
         "clsx": "2.1.1",
         "next": "14.2.4",
         "react": "18.3.1",
@@ -137,6 +139,12 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -255,6 +263,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
     },
     "node_modules/@next/env": {
       "version": "14.2.4",
@@ -444,6 +458,64 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.4.0.tgz",
+      "integrity": "sha512-YFueREq97CLslZZBI8dKzis7jMfEHSLxM+nr0Zdx1POiXFLjqqwoY5s0F1UimdBiEw/iKlHey2m56MRDv7Jtyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.4.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.4.0.tgz",
+      "integrity": "sha512-fJiYUBCJBDkjh347zZe5H81BdJ0+OGIg0X9z06v8xXUoql3MFeENUX0JsjCaVaU9A0L85PefLPGYkIoGpTnXLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.4.0",
+        "@peculiar/asn1-x509": "^2.4.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.4.0.tgz",
+      "integrity": "sha512-6PP75voaEnOSlWR9sD25iCQyLgFZHXbmxvUfnnDcfL6Zh5h2iHW38+bve4LfH7a60x7fkhZZNmiYqAlAff9Img==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.4.0",
+        "@peculiar/asn1-x509": "^2.4.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.4.0.tgz",
+      "integrity": "sha512-umbembjIWOrPSOzEGG5vxFLkeM8kzIhLkgigtsOrfLKnuzxWxejAcUX+q/SoZCdemlODOcr5WiYa7+dIEzBXZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.4.0.tgz",
+      "integrity": "sha512-F7mIZY2Eao2TaoVqigGMLv+NDdpwuBKU1fucHPONfzaBS4JXXCNCmfO0Z3dsy7JzKGqtDcYC1mr9JjaZQZNiuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.4.0",
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -454,6 +526,30 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.1.2.tgz",
+      "integrity": "sha512-VwoDfvLXSCaRiD+xCIuyslU0HLxVggeE5BL06+GbsP2l1fGf5op8e0c3ZtKoi+vSg1q4ikjtAghC23ze2Q3H9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.3.10",
+        "@peculiar/asn1-ecc": "^2.3.8",
+        "@peculiar/asn1-rsa": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-x509": "^2.3.8"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@simplewebauthn/types": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/types/-/types-12.0.0.tgz",
+      "integrity": "sha512-q6y8MkoV8V8jB4zzp18Uyj2I7oFp2/ONL8c3j8uT06AOWu3cIChc1au71QYHrP2b+xDapkGTiv+9lX7xkTlAsA==",
+      "license": "MIT"
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
@@ -996,6 +1092,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.6.tgz",
+      "integrity": "sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/async-function": {
@@ -3925,6 +4035,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "start": "next start"
   },
   "dependencies": {
+    "@simplewebauthn/server": "^13.1.2",
+    "@simplewebauthn/types": "^12.0.0",
     "clsx": "2.1.1",
     "next": "14.2.4",
     "react": "18.3.1",


### PR DESCRIPTION
## Summary
- add WebAuthn registration endpoint to issue options and verify responses
- add WebAuthn login endpoint to start authentication and set session cookie
- track users and credentials in-memory

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896a3683720832caf10b078390a12ad