### PR TITLE
Add countdown timer for next puzzle

### DIFF
--- a/components/Countdown.tsx
+++ b/components/Countdown.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { msUntilNextPuzzle } from '@/utils/date'
+
+function format(ms: number) {
+  const total = Math.max(0, Math.floor(ms / 1000))
+  const h = String(Math.floor(total / 3600)).padStart(2, '0')
+  const m = String(Math.floor((total % 3600) / 60)).padStart(2, '0')
+  const s = String(total % 60).padStart(2, '0')
+  return `${h}:${m}:${s}`
+}
+
+export default function Countdown() {
+  const router = useRouter()
+  const [remaining, setRemaining] = useState(msUntilNextPuzzle())
+
+  useEffect(() => {
+    const target = Date.now() + msUntilNextPuzzle()
+    const tick = () => {
+      const ms = target - Date.now()
+      if (ms <= 0) {
+        setRemaining(0)
+        clearInterval(id)
+        try { router.refresh() } catch {}
+      } else {
+        setRemaining(ms)
+      }
+    }
+    const id = setInterval(tick, 1000)
+    tick()
+    return () => clearInterval(id)
+  }, [router])
+
+  return (
+    <span className="text-xs font-mono text-gray-600 dark:text-gray-300">{format(remaining)}</span>
+  )
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,6 @@
-'use client'
+"use client"
 import { useRouter } from 'next/navigation'
+import Countdown from '@/components/Countdown'
 
 export default function Header({title, subtitle}:{title:string; subtitle?:string}){
   const router = useRouter()
@@ -14,12 +15,17 @@ export default function Header({title, subtitle}:{title:string; subtitle?:string
   }
 
   return (
-    <header className="px-4 pt-4 pb-2 sticky top-0 backdrop-blur bg-white/70 dark:bg-black/30 z-10 flex justify-between items-start">
+    <header
+      className="px-4 pt-4 pb-2 sticky top-0 backdrop-blur bg-white/70 dark:bg-black/30 z-10 flex justify-between items-start"
+    >
       <div>
         <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
         {subtitle && <p className="text-sm text-gray-500">{subtitle}</p>}
       </div>
-      <button onClick={handleLogout} className="text-sm text-blue-600">Logout</button>
+      <div className="flex items-center gap-2">
+        <Countdown />
+        <button onClick={handleLogout} className="text-sm text-blue-600">Logout</button>
+      </div>
     </header>
   )
 }

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -3,3 +3,48 @@ export function yyyyMmDd(d = new Date(), tz='America/Los_Angeles') {
   const parts = fmt.formatToParts(d).reduce((acc:any, p:any)=>{acc[p.type]=p.value; return acc;}, {});
   return `${parts.year}-${parts.month}-${parts.day}`;
 }
+
+function tzOffset(date: Date, tz: string) {
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+  const parts = fmt.formatToParts(date).reduce((acc: any, p: any) => { acc[p.type] = p.value; return acc; }, {});
+  const asUTC = Date.UTC(
+    parseInt(parts.year, 10),
+    parseInt(parts.month, 10) - 1,
+    parseInt(parts.day, 10),
+    parseInt(parts.hour, 10),
+    parseInt(parts.minute, 10),
+    parseInt(parts.second, 10)
+  );
+  return asUTC - date.getTime();
+}
+
+export function msUntilNextPuzzle(tz = 'America/Los_Angeles') {
+  const now = new Date();
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+  const parts = fmt.formatToParts(now).reduce((acc: any, p: any) => { acc[p.type] = p.value; return acc; }, {});
+  const year = parseInt(parts.year, 10);
+  const month = parseInt(parts.month, 10);
+  const day = parseInt(parts.day, 10);
+  const guess = new Date(Date.UTC(year, month - 1, day + 1, 0, 0, 0));
+  const offset = tzOffset(guess, tz);
+  const target = guess.getTime() - offset;
+  return target - now.getTime();
+}


### PR DESCRIPTION
## Summary
- add timezone-aware helper to compute milliseconds until the next puzzle rollover
- introduce a countdown component that refreshes when timer hits zero
- show the countdown beside the logout button in the header

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896a6d0475c832cb9d6b2a6f2c771a4