### PR TITLE
Refactor header component to accept children

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,25 +1,43 @@
 'use client'
-import { useRouter } from 'next/navigation'
 
-export default function Header({title, subtitle}:{title:string; subtitle?:string}){
+import { ReactNode } from 'react'
+import { useRouter } from 'next/navigation'
+import clsx from 'clsx'
+
+type HeaderProps = {
+  title: string
+  subtitle?: string
+  children?: ReactNode
+}
+
+export default function Header({ title, subtitle, children }: HeaderProps) {
   const router = useRouter()
 
-  async function handleLogout(){
-    try{
-      await fetch('/api/auth/logout', {method:'POST'})
+  async function handleLogout() {
+    try {
+      await fetch('/api/auth/logout', { method: 'POST' })
       router.refresh()
-    }catch(err){
+    } catch (err) {
       console.error('Logout failed', err)
     }
   }
 
   return (
-    <header className="px-4 pt-4 pb-2 sticky top-0 backdrop-blur bg-white/70 dark:bg-black/30 z-10 flex justify-between items-start">
+    <header
+      className={clsx(
+        'px-4 pt-4 pb-2 sticky top-0 backdrop-blur bg-white/70 dark:bg-black/30',
+        'z-10 flex justify-between items-start'
+      )}
+    >
       <div>
         <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
         {subtitle && <p className="text-sm text-gray-500">{subtitle}</p>}
+        {children}
       </div>
-      <button onClick={handleLogout} className="text-sm text-blue-600">Logout</button>
+      <button onClick={handleLogout} className="text-sm text-blue-600">
+        Logout
+      </button>
     </header>
   )
 }
+


### PR DESCRIPTION
## Summary
- expand `Header` to accept `children` and optional `subtitle`
- keep logout logic and integrate tailwind classes using `clsx`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896a9e2fa5c832cbd922017607afd67