### PR TITLE
Add Prisma database env config

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL="file:./prisma/dev.db"

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,7 @@ coverage/
 *.log
 .vscode/
 .DS_Store
-.env*
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # crossedwfriends
+
+## Environment variables
+
+Before running Prisma CLI commands, make sure the `DATABASE_URL` environment variable is set. A default value is provided in the project's `.env` file:
+
+```
+DATABASE_URL="file:./prisma/dev.db"
+```
+
+You can load it in your shell with `source .env` or by copying it to `.env.local`. This variable must be available whenever you run commands like `npx prisma migrate dev`.
+


### PR DESCRIPTION
## Summary
- track `.env` with default Prisma database path
- document setting `DATABASE_URL` before running Prisma
- ignore environment-specific files instead of all `.env*`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896abc7b2f0832c8df1026c4b5f6b4b