### PR TITLE
refactor: handle webauthn credential ids as buffers

### DIFF
--- a/app/api/auth/webauthn-login/route.ts
+++ b/app/api/auth/webauthn-login/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server';
+import {
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+} from '@simplewebauthn/server';
+import { userStore, rpID, expectedOrigin } from '@/lib/webauthn';
+
+/**
+ * Initiate authentication. Provide a `username` query parameter.
+ */
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const username = searchParams.get('username') ?? '';
+
+  const user = userStore.get(username);
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 400 });
+  }
+
+  const allowCreds = user.credentials.map(c => ({
+    id: Buffer.isBuffer(c.credentialID)
+      ? c.credentialID
+      : Buffer.from(c.credentialID as any, 'base64url'),
+    type: 'public-key',
+  }));
+
+  const options = generateAuthenticationOptions({
+    rpID,
+    allowCredentials: allowCreds,
+    userVerification: 'preferred',
+  });
+  user.currentChallenge = options.challenge;
+
+  // Encode IDs for the client
+  options.allowCredentials = options.allowCredentials?.map(c => ({
+    ...c,
+    id: c.id.toString('base64url'),
+  }));
+
+  return NextResponse.json(options);
+}
+
+/**
+ * Verify authentication response from the browser. Expects `username` and
+ * `assertionResponse` in the request body.
+ */
+export async function POST(req: Request) {
+  const body = await req.json();
+  const { username, assertionResponse } = body as {
+    username: string;
+    assertionResponse: any;
+  };
+
+  const user = userStore.get(username);
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 400 });
+  }
+
+  const idBuffer = Buffer.from(assertionResponse.rawId, 'base64url');
+  const authenticator = user.credentials.find(c => {
+    const stored = Buffer.isBuffer(c.credentialID)
+      ? c.credentialID
+      : Buffer.from(c.credentialID as any, 'base64url');
+    return stored.equals(idBuffer);
+  });
+  if (!authenticator) {
+    return NextResponse.json({ error: 'Authenticator not registered' }, { status: 400 });
+  }
+
+  const verification = await verifyAuthenticationResponse({
+    response: assertionResponse,
+    expectedChallenge: user.currentChallenge ?? '',
+    expectedOrigin,
+    expectedRPID: rpID,
+    authenticator: {
+      ...authenticator,
+      credentialID: Buffer.isBuffer(authenticator.credentialID)
+        ? authenticator.credentialID
+        : Buffer.from(authenticator.credentialID as any, 'base64url'),
+    },
+  });
+
+  if (verification.verified) {
+    authenticator.counter = verification.authenticationInfo.newCounter;
+  }
+
+  return NextResponse.json({ verified: verification.verified });
+}
+

--- a/app/api/auth/webauthn-register/route.ts
+++ b/app/api/auth/webauthn-register/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from 'next/server';
+import {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+} from '@simplewebauthn/server';
+import { userStore, rpID, rpName, expectedOrigin } from '@/lib/webauthn';
+
+/**
+ * Start WebAuthn registration for a user. Expect a `username` query parameter.
+ * Returns PublicKeyCredentialCreationOptions with credential IDs encoded for the client.
+ */
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const username = searchParams.get('username') ?? '';
+
+  let user = userStore.get(username);
+  if (!user) {
+    user = { id: username, username, credentials: [] };
+    userStore.set(username, user);
+  }
+
+  const options = generateRegistrationOptions({
+    rpName,
+    rpID,
+    userID: user.id,
+    userName: user.username,
+    attestationType: 'none',
+    excludeCredentials: user.credentials.map(cred => ({
+      id: cred.credentialID,
+      type: 'public-key',
+    })),
+  });
+
+  user.currentChallenge = options.challenge;
+
+  // Encode credential IDs for transport to client
+  options.excludeCredentials = options.excludeCredentials?.map(c => ({
+    ...c,
+    id: c.id.toString('base64url'),
+  }));
+
+  return NextResponse.json(options);
+}
+
+/**
+ * Verify the registration response sent back from the browser.
+ * Body should contain `username` and the attestation `response` from the browser.
+ */
+export async function POST(req: Request) {
+  const body = await req.json();
+  const { username, attestationResponse } = body as {
+    username: string;
+    attestationResponse: any;
+  };
+
+  const user = userStore.get(username);
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 400 });
+  }
+
+  const verification = await verifyRegistrationResponse({
+    response: attestationResponse,
+    expectedChallenge: user.currentChallenge ?? '',
+    expectedOrigin,
+    expectedRPID: rpID,
+  });
+
+  if (verification.verified && verification.registrationInfo) {
+    const { credentialID, credentialPublicKey, counter } = verification.registrationInfo;
+    // Store raw credential ID Buffer
+    user.credentials.push({
+      credentialID,
+      publicKey: credentialPublicKey,
+      counter,
+    });
+  }
+
+  return NextResponse.json({ verified: verification.verified });
+}
+

--- a/lib/webauthn.ts
+++ b/lib/webauthn.ts
@@ -1,0 +1,25 @@
+// Basic WebAuthn support utilities and in-memory user store
+
+export interface Credential {
+  /** Raw credential ID bytes */
+  credentialID: Buffer;
+  /** Public key returned by the authenticator */
+  publicKey: Buffer;
+  /** Sign count for the authenticator */
+  counter: number;
+}
+
+export interface User {
+  id: string;
+  username: string;
+  credentials: Credential[];
+  currentChallenge?: string;
+}
+
+/** In memory store keyed by username */
+export const userStore = new Map<string, User>();
+
+export const rpName = 'Crossed with Friends';
+export const rpID = process.env.WEBAUTHN_RPID || 'localhost';
+export const expectedOrigin = process.env.WEBAUTHN_ORIGIN || `http://localhost:3000`;
+


### PR DESCRIPTION
## Summary
- add WebAuthn utilities and in-memory user store using Buffer-based credential IDs
- register route pushes raw credentialID Buffers and encodes IDs only when sending to client
- login route converts stored IDs back to Buffers before passing to simplewebauthn

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896b25ea530832ca79eb41b809dc94c