### PR TITLE
feat: enforce unique constraint on credentialId

### DIFF
--- a/prisma/migrations/20250809024921_add-credentialid-unique/migration.sql
+++ b/prisma/migrations/20250809024921_add-credentialid-unique/migration.sql
@@ -1,0 +1,5 @@
+-- CreateTable
+CREATE TABLE "Credential" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "credentialId" TEXT NOT NULL UNIQUE
+);

--- a/prisma/migrations/migration_lock.toml
+++ b/prisma/migrations/migration_lock.toml
@@ -1,0 +1,2 @@
+# Prisma Migrate lock file
+provider = "sqlite"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,13 @@
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Credential {
+  id           Int    @id @default(autoincrement())
+  credentialId String @unique
+}


### PR DESCRIPTION
## Summary
- add Prisma schema and migration enforcing unique `credentialId`

## Testing
- `npm test`
- attempted `npx prisma migrate dev --name add-credentialid-unique --skip-generate` (failed: Failed to fetch the engine file at https://binaries.prisma.sh/... - 403 Forbidden)
- `sqlite3 prisma/dev.db < prisma/migrations/20250809024921_add-credentialid-unique/migration.sql`


------
https://chatgpt.com/codex/tasks/task_e_6896b647cef0832c8db0528196077b0b