### PR TITLE
Fix WebAuthn auth endpoints and add route tests

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -18,7 +18,7 @@ export default function LoginPage() {
         }
       })
       console.log('login credential', credential)
-      await fetch('/api/auth/login', {
+      await fetch('/api/auth/webauthn-login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ phone })

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -25,7 +25,7 @@ export default function RegisterPage() {
         }
       })
       console.log('registration credential', credential)
-      await fetch('/api/auth/register', {
+      await fetch('/api/auth/webauthn-register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ phone })

--- a/app/api/auth/webauthn-login/route.ts
+++ b/app/api/auth/webauthn-login/route.ts
@@ -24,7 +24,7 @@ export async function GET(req: Request) {
     type: 'public-key',
   }));
 
-  const options = generateAuthenticationOptions({
+  const options = await generateAuthenticationOptions({
     rpID,
     allowCredentials: allowCreds,
     userVerification: 'preferred',

--- a/app/api/auth/webauthn-register/route.ts
+++ b/app/api/auth/webauthn-register/route.ts
@@ -19,7 +19,7 @@ export async function GET(req: Request) {
     userStore.set(username, user);
   }
 
-  const options = generateRegistrationOptions({
+  const options = await generateRegistrationOptions({
     rpName,
     rpID,
     userID: user.id,

--- a/tests/auth/webauthn-login.test.ts
+++ b/tests/auth/webauthn-login.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GET as loginGet, POST as loginPost } from '../../app/api/auth/webauthn-login/route';
+import { userStore } from '../../lib/webauthn';
+
+
+describe('webauthn-login route', () => {
+  beforeEach(() => {
+    userStore.clear();
+  });
+
+  it('GET returns error for missing user', async () => {
+    const res = await loginGet(new Request('http://localhost/api/auth/webauthn-login?username=missing'));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/User not found/);
+  });
+
+  it('GET returns authentication options for existing user', async () => {
+    userStore.set('bob', { id: 'bob', username: 'bob', credentials: [] });
+    const res = await loginGet(new Request('http://localhost/api/auth/webauthn-login?username=bob'));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveProperty('challenge');
+  });
+
+  it('POST returns error for unknown user', async () => {
+    const res = await loginPost(
+      new Request('http://localhost/api/auth/webauthn-login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: 'missing', assertionResponse: {} }),
+      })
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/User not found/);
+  });
+});

--- a/tests/auth/webauthn-register.test.ts
+++ b/tests/auth/webauthn-register.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GET as registerGet, POST as registerPost } from '../../app/api/auth/webauthn-register/route';
+import { userStore } from '../../lib/webauthn';
+
+
+describe('webauthn-register route', () => {
+  beforeEach(() => {
+    userStore.clear();
+  });
+
+  it('GET returns registration options', async () => {
+    const res = await registerGet(new Request('http://localhost/api/auth/webauthn-register?username=alice'));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveProperty('challenge');
+  });
+
+  it('POST returns error for unknown user', async () => {
+    const res = await registerPost(
+      new Request('http://localhost/api/auth/webauthn-register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: 'missing', attestationResponse: {} }),
+      })
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/User not found/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname),
+    },
+  },
   test: {
     include: ['tests/**/*.test.ts'],
   },


### PR DESCRIPTION
## Summary
- point login and register pages to webauthn auth routes
- await option generators in auth routes so challenge data is returned
- add tests for webauthn auth routes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a3617d578832c933ab95e687bc358