### PR TITLE
Use phone field for WebAuthn operations

### DIFF
--- a/app/api/auth/webauthn-login/route.ts
+++ b/app/api/auth/webauthn-login/route.ts
@@ -6,13 +6,13 @@ import {
 import { userStore, rpID, expectedOrigin } from '@/lib/webauthn';
 
 /**
- * Initiate authentication. Provide a `username` query parameter.
+ * Initiate authentication. Provide a `phone` query parameter.
  */
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
-  const username = searchParams.get('username') ?? '';
+  const phone = searchParams.get('phone') ?? '';
 
-  const user = userStore.get(username);
+  const user = userStore.get(phone);
   if (!user) {
     return NextResponse.json({ error: 'User not found' }, { status: 400 });
   }
@@ -41,17 +41,17 @@ export async function GET(req: Request) {
 }
 
 /**
- * Verify authentication response from the browser. Expects `username` and
+ * Verify authentication response from the browser. Expects `phone` and
  * `assertionResponse` in the request body.
  */
 export async function POST(req: Request) {
   const body = await req.json();
-  const { username, assertionResponse } = body as {
-    username: string;
+  const { phone, assertionResponse } = body as {
+    phone: string;
     assertionResponse: any;
   };
 
-  const user = userStore.get(username);
+  const user = userStore.get(phone);
   if (!user) {
     return NextResponse.json({ error: 'User not found' }, { status: 400 });
   }

--- a/app/api/auth/webauthn-register/route.ts
+++ b/app/api/auth/webauthn-register/route.ts
@@ -6,24 +6,24 @@ import {
 import { userStore, rpID, rpName, expectedOrigin } from '@/lib/webauthn';
 
 /**
- * Start WebAuthn registration for a user. Expect a `username` query parameter.
+ * Start WebAuthn registration for a user. Expect a `phone` query parameter.
  * Returns PublicKeyCredentialCreationOptions with credential IDs encoded for the client.
  */
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
-  const username = searchParams.get('username') ?? '';
+  const phone = searchParams.get('phone') ?? '';
 
-  let user = userStore.get(username);
+  let user = userStore.get(phone);
   if (!user) {
-    user = { id: username, username, credentials: [] };
-    userStore.set(username, user);
+    user = { id: phone, phone, credentials: [] };
+    userStore.set(phone, user);
   }
 
   const options = await generateRegistrationOptions({
     rpName,
     rpID,
     userID: user.id,
-    userName: user.username,
+    userName: user.phone,
     attestationType: 'none',
     excludeCredentials: user.credentials.map(cred => ({
       id: cred.credentialID,
@@ -44,16 +44,16 @@ export async function GET(req: Request) {
 
 /**
  * Verify the registration response sent back from the browser.
- * Body should contain `username` and the attestation `response` from the browser.
+ * Body should contain `phone` and the attestation `response` from the browser.
  */
 export async function POST(req: Request) {
   const body = await req.json();
-  const { username, attestationResponse } = body as {
-    username: string;
+  const { phone, attestationResponse } = body as {
+    phone: string;
     attestationResponse: any;
   };
 
-  const user = userStore.get(username);
+  const user = userStore.get(phone);
   if (!user) {
     return NextResponse.json({ error: 'User not found' }, { status: 400 });
   }

--- a/lib/webauthn.ts
+++ b/lib/webauthn.ts
@@ -11,12 +11,12 @@ export interface Credential {
 
 export interface User {
   id: string;
-  username: string;
+  phone: string;
   credentials: Credential[];
   currentChallenge?: string;
 }
 
-/** In memory store keyed by username */
+/** In memory store keyed by phone */
 export const userStore = new Map<string, User>();
 
 export const rpName = 'Crossed with Friends';

--- a/tests/auth/webauthn-login.test.ts
+++ b/tests/auth/webauthn-login.test.ts
@@ -9,15 +9,19 @@ describe('webauthn-login route', () => {
   });
 
   it('GET returns error for missing user', async () => {
-    const res = await loginGet(new Request('http://localhost/api/auth/webauthn-login?username=missing'));
+    const res = await loginGet(
+      new Request('http://localhost/api/auth/webauthn-login?phone=missing')
+    );
     expect(res.status).toBe(400);
     const data = await res.json();
     expect(data.error).toMatch(/User not found/);
   });
 
   it('GET returns authentication options for existing user', async () => {
-    userStore.set('bob', { id: 'bob', username: 'bob', credentials: [] });
-    const res = await loginGet(new Request('http://localhost/api/auth/webauthn-login?username=bob'));
+    userStore.set('bob', { id: 'bob', phone: 'bob', credentials: [] });
+    const res = await loginGet(
+      new Request('http://localhost/api/auth/webauthn-login?phone=bob')
+    );
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data).toHaveProperty('challenge');
@@ -28,7 +32,7 @@ describe('webauthn-login route', () => {
       new Request('http://localhost/api/auth/webauthn-login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username: 'missing', assertionResponse: {} }),
+        body: JSON.stringify({ phone: 'missing', assertionResponse: {} }),
       })
     );
     expect(res.status).toBe(400);

--- a/tests/auth/webauthn-register.test.ts
+++ b/tests/auth/webauthn-register.test.ts
@@ -9,7 +9,9 @@ describe('webauthn-register route', () => {
   });
 
   it('GET returns registration options', async () => {
-    const res = await registerGet(new Request('http://localhost/api/auth/webauthn-register?username=alice'));
+    const res = await registerGet(
+      new Request('http://localhost/api/auth/webauthn-register?phone=alice')
+    );
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data).toHaveProperty('challenge');
@@ -20,7 +22,7 @@ describe('webauthn-register route', () => {
       new Request('http://localhost/api/auth/webauthn-register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username: 'missing', attestationResponse: {} }),
+        body: JSON.stringify({ phone: 'missing', attestationResponse: {} }),
       })
     );
     expect(res.status).toBe(400);


### PR DESCRIPTION
## Summary
- replace username with phone in WebAuthn registration and login APIs
- key user store entries by phone instead of username
- update WebAuthn tests to use phone

## Testing
- `npm test` *(fails: ReferenceError: describe is not defined; Error: No test suite found)*
- `npx vitest run tests/auth/webauthn-register.test.ts tests/auth/webauthn-login.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689a5db3e9e0832ca0c51315713ae5cf