### PR TITLE
feat: add base64url helpers

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,10 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import {
-  base64URLStringToBuffer,
-  bufferToBase64URLString
-} from '@simplewebauthn/browser'
+import { toArrayBuffer, fromArrayBuffer } from '@/utils/base64url'
 
 export default function LoginPage() {
   const [phone, setPhone] = useState('')
@@ -26,11 +23,11 @@ export default function LoginPage() {
 
       const publicKey: PublicKeyCredentialRequestOptions = {
         ...optionsJSON,
-        challenge: base64URLStringToBuffer(optionsJSON.challenge),
+        challenge: toArrayBuffer(optionsJSON.challenge),
         allowCredentials: optionsJSON.allowCredentials?.map(
           (cred: { id: string; type: string }) => ({
             ...cred,
-            id: base64URLStringToBuffer(cred.id)
+            id: toArrayBuffer(cred.id)
           })
         )
       }
@@ -42,17 +39,17 @@ export default function LoginPage() {
       const { id, rawId, response, type, authenticatorAttachment } = credential
       const assertionResponse = {
         id,
-        rawId: bufferToBase64URLString(rawId),
+        rawId: fromArrayBuffer(rawId),
         response: {
-          authenticatorData: bufferToBase64URLString(
+          authenticatorData: fromArrayBuffer(
             (response as AuthenticatorAssertionResponse).authenticatorData
           ),
-          clientDataJSON: bufferToBase64URLString(response.clientDataJSON),
-          signature: bufferToBase64URLString(
+          clientDataJSON: fromArrayBuffer(response.clientDataJSON),
+          signature: fromArrayBuffer(
             (response as AuthenticatorAssertionResponse).signature
           ),
           userHandle: response.userHandle
-            ? bufferToBase64URLString(response.userHandle)
+            ? fromArrayBuffer(response.userHandle)
             : null
         },
         type,

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,10 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import {
-  base64URLStringToBuffer,
-  bufferToBase64URLString
-} from '@simplewebauthn/browser'
+import { toArrayBuffer, fromArrayBuffer } from '@/utils/base64url'
 
 export default function RegisterPage() {
   const [phone, setPhone] = useState('')
@@ -26,15 +23,15 @@ export default function RegisterPage() {
 
       const publicKey: PublicKeyCredentialCreationOptions = {
         ...optionsJSON,
-        challenge: base64URLStringToBuffer(optionsJSON.challenge),
+        challenge: toArrayBuffer(optionsJSON.challenge),
         user: {
           ...optionsJSON.user,
-          id: base64URLStringToBuffer(optionsJSON.user.id)
+          id: toArrayBuffer(optionsJSON.user.id)
         },
         excludeCredentials: optionsJSON.excludeCredentials?.map(
           (cred: { id: string; type: string }) => ({
             ...cred,
-            id: base64URLStringToBuffer(cred.id)
+            id: toArrayBuffer(cred.id)
           })
         )
       }
@@ -47,12 +44,12 @@ export default function RegisterPage() {
         credential
       const attestationResponse = {
         id,
-        rawId: bufferToBase64URLString(rawId),
+        rawId: fromArrayBuffer(rawId),
         response: {
-          attestationObject: bufferToBase64URLString(
+          attestationObject: fromArrayBuffer(
             (response as AuthenticatorAttestationResponse).attestationObject
           ),
-          clientDataJSON: bufferToBase64URLString(response.clientDataJSON)
+          clientDataJSON: fromArrayBuffer(response.clientDataJSON)
         },
         type,
         authenticatorAttachment,

--- a/tests/utils/base64url.test.ts
+++ b/tests/utils/base64url.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { toArrayBuffer, fromArrayBuffer } from '../../utils/base64url';
+
+const textDecoder = new TextDecoder();
+
+describe('base64url helpers', () => {
+  it('round-trips base64url string', () => {
+    const original = 'SGVsbG8sIHdvcmxkIQ';
+    const buf = toArrayBuffer(original);
+    const encoded = fromArrayBuffer(buf);
+    expect(encoded).toBe(original);
+    expect(textDecoder.decode(buf)).toBe('Hello, world!');
+  });
+
+  it('round-trips ArrayBuffer', () => {
+    const bytes = new Uint8Array([251, 239, 190, 173]).buffer;
+    const encoded = fromArrayBuffer(bytes);
+    const decoded = toArrayBuffer(encoded);
+    expect(new Uint8Array(decoded)).toEqual(new Uint8Array(bytes));
+  });
+});

--- a/utils/base64url.ts
+++ b/utils/base64url.ts
@@ -1,0 +1,20 @@
+export function toArrayBuffer(base64url: string): ArrayBuffer {
+  const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64.padEnd(base64.length + (4 - (base64.length % 4)) % 4, '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+export function fromArrayBuffer(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  const base64 = btoa(binary);
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '');
+}


### PR DESCRIPTION
## Summary
- add array buffer base64url helpers
- use new helpers in auth login and registration pages
- test base64url round-trip conversions

## Testing
- `npm test` *(fails: components/Grid.test.tsx describe is not defined; test/users.test.ts no test suite found)*

------
https://chatgpt.com/codex/tasks/task_e_689a60601f50832c89e055822a4d5f29