### PR TITLE
Require device biometrics for WebAuthn

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,6 @@ You can load it in your shell with `source .env` or by copying it to `.env.local
   ```bash
   npm run lint
   ```
+
+- WebAuthn authentication only accepts platform biometrics (e.g., Face ID).
+  External security keys are not supported.

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -29,7 +29,8 @@ export default function LoginPage() {
             ...cred,
             id: toArrayBuffer(cred.id)
           })
-        )
+        ),
+        userVerification: 'required'
       }
 
       const credential = (await navigator.credentials.get({

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -33,7 +33,11 @@ export default function RegisterPage() {
             ...cred,
             id: toArrayBuffer(cred.id)
           })
-        )
+        ),
+        authenticatorSelection: {
+          authenticatorAttachment: 'platform',
+          userVerification: 'required'
+        }
       }
 
       const credential = (await navigator.credentials.create({

--- a/app/api/auth/webauthn-login/route.ts
+++ b/app/api/auth/webauthn-login/route.ts
@@ -27,7 +27,11 @@ export async function GET(req: Request) {
   const options = await generateAuthenticationOptions({
     rpID,
     allowCredentials: allowCreds,
-    userVerification: 'preferred',
+    userVerification: 'required',
+    authenticatorSelection: {
+      authenticatorAttachment: 'platform',
+      userVerification: 'required',
+    },
   });
   user.currentChallenge = options.challenge;
 

--- a/app/api/auth/webauthn-register/route.ts
+++ b/app/api/auth/webauthn-register/route.ts
@@ -25,6 +25,10 @@ export async function GET(req: Request) {
     userID: user.id,
     userName: user.phone,
     attestationType: 'none',
+    authenticatorSelection: {
+      authenticatorAttachment: 'platform',
+      userVerification: 'required',
+    },
     excludeCredentials: user.credentials.map(cred => ({
       id: cred.credentialID,
       type: 'public-key',

--- a/tests/auth/webauthn-login.test.ts
+++ b/tests/auth/webauthn-login.test.ts
@@ -25,6 +25,7 @@ describe('webauthn-login route', () => {
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data).toHaveProperty('challenge');
+    expect(data.userVerification).toBe('required');
   });
 
   it('POST returns error for unknown user', async () => {

--- a/tests/auth/webauthn-register.test.ts
+++ b/tests/auth/webauthn-register.test.ts
@@ -15,6 +15,8 @@ describe('webauthn-register route', () => {
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data).toHaveProperty('challenge');
+    expect(data.authenticatorSelection.authenticatorAttachment).toBe('platform');
+    expect(data.authenticatorSelection.userVerification).toBe('required');
   });
 
   it('POST returns error for unknown user', async () => {


### PR DESCRIPTION
## Summary
- restrict WebAuthn registration to platform authenticators with required user verification
- enforce required user verification during WebAuthn login
- document that only device biometrics (e.g., Face ID) are supported

## Testing
- `npm test` *(fails: components/Grid.test.tsx describe is not defined; test/users.test.ts No test suite found)*

------
https://chatgpt.com/codex/tasks/task_e_689a61b6ff90832c868c1f447c487683