### PR TITLE
test: migrate node tests to vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dev": "next dev --hostname 0.0.0.0 -p 3000",
     "build": "next build",
     "start": "next start",
-    "test": "vitest run && node --import tsx --test test/*.test.*",
+    "test": "vitest run",
     "lint": "eslint .",
     "generate:daily": "tsx scripts/generateDaily.ts",
     "db:migrate": "prisma migrate deploy",

--- a/test/placeholder.test.js
+++ b/test/placeholder.test.js
@@ -1,6 +1,0 @@
-import test from 'node:test';
-import assert from 'node:assert/strict';
-
-test('placeholder', () => {
-  assert.strictEqual(1 + 1, 2);
-});

--- a/tests/placeholder.test.ts
+++ b/tests/placeholder.test.ts
@@ -1,0 +1,5 @@
+import { test, expect } from 'vitest';
+
+test('placeholder', () => {
+  expect(1 + 1).toBe(2);
+});

--- a/tests/webauthn.test.ts
+++ b/tests/webauthn.test.ts
@@ -1,5 +1,4 @@
-import { test, before, after } from 'node:test';
-import assert from 'node:assert/strict';
+import { test, beforeAll, afterAll, expect } from 'vitest';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -7,28 +6,28 @@ import { execSync } from 'node:child_process';
 
 let webauthn: typeof import('../lib/webauthn');
 
-before(async () => {
+beforeAll(async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'prisma-user-'));
   process.env.DATABASE_URL = `file:${path.join(dir, 'test.db')}`;
   execSync('npx prisma migrate deploy', { env: process.env });
   webauthn = await import('../lib/webauthn');
 });
 
-after(async () => {
+afterAll(async () => {
   await webauthn.prisma.$disconnect();
 });
 
 test('getOrCreateUser returns persistent user', async () => {
   const created = await webauthn.getOrCreateUser('123');
-  assert.equal(created.phoneNumber, '123');
+  expect(created.phoneNumber).toBe('123');
   const fetched = await webauthn.getOrCreateUser('123');
-  assert.equal(fetched.id, created.id);
+  expect(fetched.id).toBe(created.id);
 });
 
 test('setChallenge stores challenge', async () => {
   await webauthn.setChallenge('555', 'foo');
   const user = await webauthn.getUser('555');
-  assert.equal(user?.currentChallenge, 'foo');
+  expect(user?.currentChallenge).toBe('foo');
 });
 
 test('saveCredential and updateCounter persist data', async () => {
@@ -41,13 +40,11 @@ test('saveCredential and updateCounter persist data', async () => {
   await webauthn.saveCredential('999', credential);
   await webauthn.updateCounter('999', 2);
   const user = await webauthn.getUser('999');
-  assert.equal(user?.counter, 2);
-  assert.equal(
-    Buffer.from(user?.credentialId ?? []).toString('hex'),
+  expect(user?.counter).toBe(2);
+  expect(Buffer.from(user?.credentialId ?? []).toString('hex')).toBe(
     credential.credentialID.toString('hex'),
   );
-  assert.equal(
-    Buffer.from(user?.publicKey ?? []).toString('hex'),
+  expect(Buffer.from(user?.publicKey ?? []).toString('hex')).toBe(
     credential.publicKey.toString('hex'),
   );
 });


### PR DESCRIPTION
## Summary
- convert legacy node tests to Vitest and relocate under `tests/`
- drop Node's test runner in favor of a single `vitest run`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a71763fec832cb3e6f71a822f91d3