### PR TITLE
refactor: use Buffer for base64url helpers

### DIFF
--- a/tests/utils/base64url.test.ts
+++ b/tests/utils/base64url.test.ts
@@ -1,20 +1,20 @@
 import { describe, it, expect } from 'vitest';
 import { toArrayBuffer, fromArrayBuffer } from '../../utils/base64url';
 
-const textDecoder = new TextDecoder();
-
 describe('base64url helpers', () => {
   it('round-trips base64url string', () => {
-    const original = 'SGVsbG8sIHdvcmxkIQ';
+    const message = 'Hello, world!';
+    const original = Buffer.from(message).toString('base64url');
     const buf = toArrayBuffer(original);
     const encoded = fromArrayBuffer(buf);
     expect(encoded).toBe(original);
-    expect(textDecoder.decode(buf)).toBe('Hello, world!');
+    expect(Buffer.from(buf).toString()).toBe(message);
   });
 
   it('round-trips ArrayBuffer', () => {
     const bytes = new Uint8Array([251, 239, 190, 173]).buffer;
     const encoded = fromArrayBuffer(bytes);
+    expect(encoded).toBe(Buffer.from(bytes).toString('base64url'));
     const decoded = toArrayBuffer(encoded);
     expect(new Uint8Array(decoded)).toEqual(new Uint8Array(bytes));
   });

--- a/utils/base64url.ts
+++ b/utils/base64url.ts
@@ -1,20 +1,10 @@
+import { Buffer } from 'buffer';
+
 export function toArrayBuffer(base64url: string): ArrayBuffer {
-  const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
-  const padded = base64.padEnd(base64.length + (4 - (base64.length % 4)) % 4, '=');
-  const binary = atob(padded);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes.buffer;
+  const buf = Buffer.from(base64url, 'base64url');
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
 }
 
 export function fromArrayBuffer(buffer: ArrayBuffer): string {
-  const bytes = new Uint8Array(buffer);
-  let binary = '';
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-  const base64 = btoa(binary);
-  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '');
+  return Buffer.from(buffer).toString('base64url');
 }


### PR DESCRIPTION
## Summary
- replace manual atob/btoa logic with Buffer base64url helpers
- adjust tests for Buffer-based base64url encoding

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a75ee725c832c9ee927ceca711d47