### PR TITLE
refactor: extract puzzle and viewport hooks

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,98 +4,27 @@ import Header from '@/components/Header'
 import Grid from '@/components/Grid'
 import ClueBar from '@/components/ClueBar'
 import ClueList from '@/components/ClueList'
-import { loadDemoFromFile } from '@/lib/puzzle'
-import { yyyyMmDd } from '@/utils/date'
-import { KEYBOARD_INSET_THRESHOLD } from '@/utils/constants'
-import { useMemo, useState, useEffect, useRef } from 'react'
+import usePuzzle from '@/hooks/usePuzzle'
+import useKeyboardViewport from '@/hooks/useKeyboardViewport'
+import { useMemo, useState, useRef, useEffect } from 'react'
 
 export default function Page() {
-  const [demo, setDemo] = useState<boolean | null>(null)
-  const [puzzle, setPuzzle] = useState<any | null>(null)
-  const [cells, setCells] = useState<any[]>([])
-  const [active, setActive] = useState<{ number: number | null, dir: 'across' | 'down' }>({ number: null, dir: 'across' })
-  const [jump, setJump] = useState<{ number: number, dir: 'across' | 'down', nonce: number } | undefined>()
+  const { puzzle, cells, setCells } = usePuzzle()
+  const [active, setActive] = useState<{ number: number | null; dir: 'across' | 'down' }>({ number: null, dir: 'across' })
+  const [jump, setJump] = useState<{ number: number; dir: 'across' | 'down'; nonce: number } | undefined>()
   const [clueBarH, setClueBarH] = useState(0)
-  const [kbOpen, setKbOpen] = useState(false)
-  const [scale, setScale] = useState(1)
-  const [seed, setSeed] = useState(() => yyyyMmDd(new Date(), 'America/Los_Angeles'))
 
   const gridOuterRef = useRef<HTMLDivElement>(null)
-  const gridInnerRef = useRef<HTMLDivElement>(null) // for measuring natural height
+  const gridInnerRef = useRef<HTMLDivElement>(null)
+
+  const { kbOpen, scale } = useKeyboardViewport(gridInnerRef, clueBarH, active)
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search)
-    setDemo(params.get('demo') === '1')
-  }, [])
-
-  useEffect(() => {
-    if (demo === null) return
-    ; (async () => {
-      if (demo) {
-        try {
-          const p = await loadDemoFromFile()
-          setPuzzle(p); setCells(p.cells); return
-        } catch { }
-      }
-      const res = await fetch(`/api/puzzle/${seed}`)
-      const p = await res.json()
-      setPuzzle(p); setCells(p.cells)
-    })()
-  }, [demo, seed])
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      const next = yyyyMmDd(new Date(), 'America/Los_Angeles')
-      if (!demo && next !== seed) {
-        setSeed(next)
-        setPuzzle(null)
-        setCells([])
-        setActive({ number: null, dir: 'across' })
-        setJump(undefined)
-      }
-    }, 60 * 1000)
-    return () => clearInterval(interval)
-  }, [demo, seed])
-
-  // Detect keyboard via VisualViewport inset
-  useEffect(() => {
-    const vv = (window as any).visualViewport
-    if (!vv) return
-    const onResize = () => {
-      const inset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop)
-      const isKeyboard = inset > KEYBOARD_INSET_THRESHOLD
-      setKbOpen(isKeyboard)
-      // recompute scale on each change
-      requestAnimationFrame(() => {
-        const inner = gridInnerRef.current
-        if (!inner) return
-        const naturalHeight = inner.offsetHeight // unscaled height of the grid
-        // available height inside viewport
-        const available = vv.height - clueBarH - 12 /* breathing room */
-        const s = Math.min(1, Math.max(0.6, available / naturalHeight)) // cap between 0.6 and 1
-        setScale(s)
-      })
+    if (!puzzle) {
+      setActive({ number: null, dir: 'across' })
+      setJump(undefined)
     }
-    onResize()
-    vv.addEventListener('resize', onResize)
-    vv.addEventListener('scroll', onResize)
-    return () => {
-      vv.removeEventListener('resize', onResize)
-      vv.removeEventListener('scroll', onResize)
-    }
-  }, [clueBarH])
-
-  // also recompute when active clue changes (grid height can wiggle very slightly)
-  useEffect(() => {
-    const inner = gridInnerRef.current
-    if (!inner) return
-    const vv = (window as any).visualViewport
-    if (!vv) return
-    const naturalHeight = inner.offsetHeight
-    const available = vv.height - clueBarH - 12
-    const s = Math.min(1, Math.max(0.6, available / naturalHeight))
-    setScale(s)
-  }, [clueBarH, active])
+  }, [puzzle])
 
   const clueText = useMemo(() => {
     if (!puzzle || !active.number) return ''
@@ -108,7 +37,7 @@ export default function Page() {
     setJump({ number, dir, nonce: Date.now() })
   }
 
-  if (demo === null || !puzzle) {
+  if (!puzzle) {
     return (
       <main className="pb-28">
         <Header title="Loading…" subtitle="Fetching puzzle" />
@@ -119,14 +48,11 @@ export default function Page() {
 
   return (
     <main className="pb-28" style={{ paddingBottom: clueBarH + 16 }}>
-      {/* Hide header when keyboard is open to buy vertical room */}
       {!kbOpen && (
         <Header title={puzzle.title ?? 'Today'} subtitle={puzzle.theme ?? ''} />
       )}
 
-      {/* Scale-to-fit wrapper */}
-      <div ref={gridOuterRef}
-        style={{ transform: `scale(${scale})`, transformOrigin: 'top center' }}>
+      <div ref={gridOuterRef} style={{ transform: `scale(${scale})`, transformOrigin: 'top center' }}>
         <div ref={gridInnerRef}>
           <Grid
             cells={cells}
@@ -157,3 +83,4 @@ export default function Page() {
     </main>
   )
 }
+

--- a/hooks/useKeyboardViewport.ts
+++ b/hooks/useKeyboardViewport.ts
@@ -1,0 +1,54 @@
+'use client'
+
+import { RefObject, useEffect, useState } from 'react'
+import { KEYBOARD_INSET_THRESHOLD } from '@/utils/constants'
+
+type Dir = { number: number | null; dir: 'across' | 'down' }
+
+export default function useKeyboardViewport(
+  gridInnerRef: RefObject<HTMLDivElement>,
+  clueBarH: number,
+  active?: Dir
+) {
+  const [kbOpen, setKbOpen] = useState(false)
+  const [scale, setScale] = useState(1)
+
+  useEffect(() => {
+    const vv = (window as any).visualViewport
+    if (!vv) return
+    const onResize = () => {
+      const inset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop)
+      const isKeyboard = inset > KEYBOARD_INSET_THRESHOLD
+      setKbOpen(isKeyboard)
+      requestAnimationFrame(() => {
+        const inner = gridInnerRef.current
+        if (!inner) return
+        const naturalHeight = inner.offsetHeight
+        const available = vv.height - clueBarH - 12
+        const s = Math.min(1, Math.max(0.6, available / naturalHeight))
+        setScale(s)
+      })
+    }
+    onResize()
+    vv.addEventListener('resize', onResize)
+    vv.addEventListener('scroll', onResize)
+    return () => {
+      vv.removeEventListener('resize', onResize)
+      vv.removeEventListener('scroll', onResize)
+    }
+  }, [clueBarH, gridInnerRef])
+
+  useEffect(() => {
+    const inner = gridInnerRef.current
+    if (!inner) return
+    const vv = (window as any).visualViewport
+    if (!vv) return
+    const naturalHeight = inner.offsetHeight
+    const available = vv.height - clueBarH - 12
+    const s = Math.min(1, Math.max(0.6, available / naturalHeight))
+    setScale(s)
+  }, [clueBarH, active, gridInnerRef])
+
+  return { kbOpen, scale }
+}
+

--- a/hooks/usePuzzle.ts
+++ b/hooks/usePuzzle.ts
@@ -1,0 +1,50 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { loadDemoFromFile, Puzzle, Cell } from '@/lib/puzzle'
+import { yyyyMmDd } from '@/utils/date'
+
+export default function usePuzzle() {
+  const [demo, setDemo] = useState<boolean | null>(null)
+  const [puzzle, setPuzzle] = useState<Puzzle | null>(null)
+  const [cells, setCells] = useState<Cell[]>([])
+  const [seed, setSeed] = useState(() => yyyyMmDd(new Date(), 'America/Los_Angeles'))
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    setDemo(params.get('demo') === '1')
+  }, [])
+
+  useEffect(() => {
+    if (demo === null) return
+    ;(async () => {
+      if (demo) {
+        try {
+          const p = await loadDemoFromFile()
+          setPuzzle(p)
+          setCells(p.cells)
+          return
+        } catch {}
+      }
+      const res = await fetch(`/api/puzzle/${seed}`)
+      const p = await res.json()
+      setPuzzle(p)
+      setCells(p.cells)
+    })()
+  }, [demo, seed])
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const next = yyyyMmDd(new Date(), 'America/Los_Angeles')
+      if (!demo && next !== seed) {
+        setSeed(next)
+        setPuzzle(null)
+        setCells([])
+      }
+    }, 60 * 1000)
+    return () => clearInterval(interval)
+  }, [demo, seed])
+
+  return { puzzle, cells, setCells }
+}
+


### PR DESCRIPTION
## Summary
- factor out puzzle loading and seeding logic into `usePuzzle`
- add `useKeyboardViewport` for keyboard visibility and scaling
- refactor page to compose new hooks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a7ac9e9cc832c93e3d076c6379ae1