### PR TITLE
feat: add group models

### DIFF
--- a/prisma/migrations/20250812162640_add_groups/migration.sql
+++ b/prisma/migrations/20250812162640_add_groups/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "Group" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "GroupMember" (
+    "groupId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    PRIMARY KEY ("groupId", "userId"),
+    CONSTRAINT "GroupMember_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "Group" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "GroupMember_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,10 +11,28 @@ datasource db {
 }
 
 model User {
-  id           String @id @default(cuid())
-  phoneNumber  String @unique
-  credentialId Bytes?
-  publicKey    Bytes?
-  counter      Int?
+  id               String        @id @default(cuid())
+  phoneNumber      String        @unique
+  credentialId     Bytes?
+  publicKey        Bytes?
+  counter          Int?
   currentChallenge String?
+  memberships      GroupMember[]
+}
+
+model Group {
+  id        String        @id @default(cuid())
+  name      String
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
+  members   GroupMember[]
+}
+
+model GroupMember {
+  group   Group  @relation(fields: [groupId], references: [id])
+  groupId String
+  user    User   @relation(fields: [userId], references: [id])
+  userId  String
+
+  @@id([groupId, userId])
 }


### PR DESCRIPTION
## Summary
- add `Group` and `GroupMember` models
- link `User` to memberships
- run migration for groups tables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b6abb7d94832cb5464bd0b545a098