### PR TITLE
Add default group to seed script

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -5,7 +5,14 @@ const prisma = new PrismaClient();
 async function main() {
   const count = await prisma.user.count();
   if (count === 0) {
-    await prisma.user.create({ data: { phoneNumber: 'seed-user' } });
+    const user = await prisma.user.create({ data: { phoneNumber: 'seed-user' } });
+    const group = await prisma.group.create({ data: { name: 'Initial Puzzle Group' } });
+    await prisma.groupMember.create({
+      data: {
+        userId: user.id,
+        groupId: group.id,
+      },
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- seed a default "Initial Puzzle Group" and link the seeded user to it

## Testing
- `npm run lint`
- `npm test`
- `npm run db:seed`


------
https://chatgpt.com/codex/tasks/task_e_689b6d125f2c832ca5172259d9186b23