### PR TITLE
Add group chat messaging

### DIFF
--- a/app/api/groups/[groupId]/messages/route.ts
+++ b/app/api/groups/[groupId]/messages/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { sendMessage, listMessages } from '@/lib/chat';
+
+export async function GET(
+  req: Request,
+  { params }: { params: { groupId: string } }
+) {
+  const userId = req.headers.get('x-user-id') ?? '';
+  try {
+    const messages = await listMessages(params.groupId, userId);
+    return NextResponse.json(messages);
+  } catch (err) {
+    if (err instanceof Error && /not a member/i.test(err.message)) {
+      return NextResponse.json({ error: 'Not a member' }, { status: 403 });
+    }
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: { groupId: string } }
+) {
+  const userId = req.headers.get('x-user-id') ?? '';
+  let body: { content?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+  const content = body.content;
+  if (!content || typeof content !== 'string') {
+    return NextResponse.json({ error: 'Invalid content' }, { status: 400 });
+  }
+  try {
+    const message = await sendMessage(params.groupId, userId, content);
+    return NextResponse.json(message, { status: 201 });
+  } catch (err) {
+    if (err instanceof Error && /not a member/i.test(err.message)) {
+      return NextResponse.json({ error: 'Not a member' }, { status: 403 });
+    }
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/components/Chat.tsx
+++ b/components/Chat.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState, useEffect, FormEvent } from 'react';
+
+interface Message {
+  id: string;
+  userId: string;
+  content: string;
+  createdAt: string;
+}
+
+export default function Chat({ groupId, userId }: { groupId: string; userId: string }) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [content, setContent] = useState('');
+
+  async function fetchMessages() {
+    const res = await fetch(`/api/groups/${groupId}/messages`, {
+      headers: { 'x-user-id': userId },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setMessages(data);
+    }
+  }
+
+  useEffect(() => {
+    fetchMessages();
+    const interval = setInterval(fetchMessages, 5000);
+    return () => clearInterval(interval);
+  }, [groupId, userId]);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!content.trim()) return;
+    await fetch(`/api/groups/${groupId}/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-user-id': userId,
+      },
+      body: JSON.stringify({ content }),
+    });
+    setContent('');
+    fetchMessages();
+  }
+
+  return (
+    <div className="flex flex-col space-y-2">
+      <div className="flex-1 overflow-y-auto border p-2">
+        {messages.map((m) => (
+          <div key={m.id} className="mb-1">
+            <span className="font-bold mr-1">{m.userId}:</span>
+            <span>{m.content}</span>
+          </div>
+        ))}
+      </div>
+      <form onSubmit={handleSubmit} className="flex space-x-2">
+        <input
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          className="border p-1 flex-1"
+        />
+        <button type="submit" className="px-2 py-1 bg-blue-500 text-white">
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/lib/chat.ts
+++ b/lib/chat.ts
@@ -1,0 +1,31 @@
+import { prisma } from './group';
+
+export async function sendMessage(groupId: string, userId: string, content: string) {
+  if (!content || !content.trim()) {
+    throw new Error('Content required');
+  }
+  const membership = await prisma.groupMember.findUnique({
+    where: { groupId_userId: { groupId, userId } },
+  });
+  if (!membership) {
+    throw new Error('Not a member');
+  }
+  return prisma.chatMessage.create({
+    data: { groupId, userId, content },
+  });
+}
+
+export async function listMessages(groupId: string, userId: string) {
+  const membership = await prisma.groupMember.findUnique({
+    where: { groupId_userId: { groupId, userId } },
+  });
+  if (!membership) {
+    throw new Error('Not a member');
+  }
+  return prisma.chatMessage.findMany({
+    where: { groupId },
+    orderBy: { createdAt: 'asc' },
+  });
+}
+
+export { prisma };

--- a/prisma/migrations/20250812175522_chat_messages/migration.sql
+++ b/prisma/migrations/20250812175522_chat_messages/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "ChatMessage" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "groupId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ChatMessage_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "Group" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ChatMessage_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "ChatMessage_groupId_createdAt_idx" ON "ChatMessage"("groupId", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
   counter          Int?
   currentChallenge String?
   memberships      GroupMember[]
+  messages         ChatMessage[]
 }
 
 model Group {
@@ -26,6 +27,7 @@ model Group {
   createdAt DateTime      @default(now())
   updatedAt DateTime      @updatedAt
   members   GroupMember[]
+  messages  ChatMessage[]
 }
 
 model GroupMember {
@@ -35,4 +37,16 @@ model GroupMember {
   userId  String
 
   @@id([groupId, userId])
+}
+
+model ChatMessage {
+  id        String   @id @default(cuid())
+  group     Group    @relation(fields: [groupId], references: [id])
+  groupId   String
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String
+  content   String
+  createdAt DateTime @default(now())
+
+  @@index([groupId, createdAt])
 }

--- a/tests/chat/chat.api.test.ts
+++ b/tests/chat/chat.api.test.ts
@@ -1,0 +1,114 @@
+import { execSync } from 'child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.join(__dirname, '..', '..');
+const dbFile = path.join(projectRoot, 'tests', `chat-api-${process.env.VITEST_POOL_ID || '0'}.db`);
+process.env.DATABASE_URL = `file:${dbFile}`;
+execSync('npx prisma migrate deploy', { stdio: 'ignore', cwd: projectRoot });
+
+const { GET: messagesGet, POST: messagesPost } = await import(
+  '../../app/api/groups/[groupId]/messages/route'
+);
+const { prisma } = await import('../../lib/chat');
+
+describe('chat API routes', () => {
+  beforeEach(async () => {
+    await prisma.chatMessage.deleteMany();
+    await prisma.groupMember.deleteMany();
+    await prisma.group.deleteMany();
+    await prisma.user.deleteMany();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it('POST creates message for member', async () => {
+    const group = await prisma.group.create({ data: { name: 'api g1' } });
+    const user = await prisma.user.create({ data: { phoneNumber: '111' } });
+    await prisma.groupMember.create({ data: { groupId: group.id, userId: user.id } });
+    const res = await messagesPost(
+      new Request(`http://localhost/api/groups/${group.id}/messages`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-user-id': user.id,
+        },
+        body: JSON.stringify({ content: 'hello' }),
+      }),
+      { params: { groupId: group.id } }
+    );
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.content).toBe('hello');
+  });
+
+  it('GET returns messages in order', async () => {
+    const group = await prisma.group.create({ data: { name: 'api g2' } });
+    const user = await prisma.user.create({ data: { phoneNumber: '222' } });
+    await prisma.groupMember.create({ data: { groupId: group.id, userId: user.id } });
+    await messagesPost(
+      new Request(`http://localhost/api/groups/${group.id}/messages`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-user-id': user.id,
+        },
+        body: JSON.stringify({ content: 'first' }),
+      }),
+      { params: { groupId: group.id } }
+    );
+    await messagesPost(
+      new Request(`http://localhost/api/groups/${group.id}/messages`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-user-id': user.id,
+        },
+        body: JSON.stringify({ content: 'second' }),
+      }),
+      { params: { groupId: group.id } }
+    );
+    const res = await messagesGet(
+      new Request(`http://localhost/api/groups/${group.id}/messages`, {
+        headers: { 'x-user-id': user.id },
+      }),
+      { params: { groupId: group.id } }
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.map((m: any) => m.content)).toEqual(['first', 'second']);
+  });
+
+  it('POST rejects non-member', async () => {
+    const group = await prisma.group.create({ data: { name: 'api g3' } });
+    const user = await prisma.user.create({ data: { phoneNumber: '333' } });
+    const res = await messagesPost(
+      new Request(`http://localhost/api/groups/${group.id}/messages`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-user-id': user.id,
+        },
+        body: JSON.stringify({ content: 'hi' }),
+      }),
+      { params: { groupId: group.id } }
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('GET rejects non-member', async () => {
+    const group = await prisma.group.create({ data: { name: 'api g4' } });
+    const user = await prisma.user.create({ data: { phoneNumber: '444' } });
+    const res = await messagesGet(
+      new Request(`http://localhost/api/groups/${group.id}/messages`, {
+        headers: { 'x-user-id': user.id },
+      }),
+      { params: { groupId: group.id } }
+    );
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/chat/chat.unit.test.ts
+++ b/tests/chat/chat.unit.test.ts
@@ -1,0 +1,55 @@
+import { execSync } from 'child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.join(__dirname, '..', '..');
+const dbFile = path.join(projectRoot, 'tests', `chat-unit-${process.env.VITEST_POOL_ID || '0'}.db`);
+process.env.DATABASE_URL = `file:${dbFile}`;
+execSync('npx prisma migrate deploy', { stdio: 'ignore', cwd: projectRoot });
+
+const { sendMessage, listMessages, prisma } = await import('../../lib/chat');
+
+describe('chat service', () => {
+  beforeEach(async () => {
+    await prisma.chatMessage.deleteMany();
+    await prisma.groupMember.deleteMany();
+    await prisma.group.deleteMany();
+    await prisma.user.deleteMany();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it('sendMessage creates message', async () => {
+    const group = await prisma.group.create({ data: { name: 'g1' } });
+    const user = await prisma.user.create({ data: { phoneNumber: '111' } });
+    await prisma.groupMember.create({ data: { groupId: group.id, userId: user.id } });
+    const msg = await sendMessage(group.id, user.id, 'hello');
+    expect(msg.content).toBe('hello');
+  });
+
+  it('listMessages returns in order', async () => {
+    const group = await prisma.group.create({ data: { name: 'g2' } });
+    const user = await prisma.user.create({ data: { phoneNumber: '222' } });
+    await prisma.groupMember.create({ data: { groupId: group.id, userId: user.id } });
+    await sendMessage(group.id, user.id, 'first');
+    await sendMessage(group.id, user.id, 'second');
+    const msgs = await listMessages(group.id, user.id);
+    expect(msgs.map((m) => m.content)).toEqual(['first', 'second']);
+  });
+
+  it('sendMessage rejects non-member', async () => {
+    const group = await prisma.group.create({ data: { name: 'g3' } });
+    const user = await prisma.user.create({ data: { phoneNumber: '333' } });
+    await expect(sendMessage(group.id, user.id, 'hi')).rejects.toThrow();
+  });
+
+  it('listMessages rejects non-member', async () => {
+    const group = await prisma.group.create({ data: { name: 'g4' } });
+    const user = await prisma.user.create({ data: { phoneNumber: '444' } });
+    await expect(listMessages(group.id, user.id)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add `ChatMessage` model and migration
- implement chat service helpers and group message API routes
- create polling chat component
- test message creation, ordering, and authorization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b7f7a77a8832cb62356ad5679b3d3