### PR TITLE
Handle missing puzzle fetch or cells

### DIFF
--- a/hooks/usePuzzle.ts
+++ b/hooks/usePuzzle.ts
@@ -26,10 +26,18 @@ export default function usePuzzle() {
           return
         } catch {}
       }
-      const res = await fetch(`/api/puzzle/${seed}`)
-      const p = await res.json()
-      setPuzzle(p)
-      setCells(p.cells)
+      try {
+        const res = await fetch(`/api/puzzle/${seed}`)
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const p: Puzzle = await res.json()
+        if (!Array.isArray((p as any)?.cells)) throw new Error('Missing cells')
+        setPuzzle(p)
+        setCells(p.cells)
+      } catch (err) {
+        console.error('Failed to load puzzle', err)
+        setPuzzle(null)
+        setCells([])
+      }
     })()
   }, [demo, seed])
 


### PR DESCRIPTION
## Summary
- Improve puzzle loading hook to guard against failed fetch or missing data
- Log and reset state when puzzle retrieval fails

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b8353f82c832c9aa7b1a606ff1736