### PR TITLE
Use Wikipedia news feed for current events

### DIFF
--- a/scripts/generateDaily.ts
+++ b/scripts/generateDaily.ts
@@ -8,10 +8,11 @@ import { logInfo, logError } from '../utils/logger';
 async function main() {
   const date = yyyyMmDd();
   const seed = `${date}:seasonal,funFacts,currentEvents`;
+  const puzzleDate = new Date(`${date}T00:00:00Z`);
   const [seasonal, funFacts, currentEvents] = await Promise.all([
-    getSeasonalWords(new Date()),
+    getSeasonalWords(puzzleDate),
     getFunFactWords(),
-    getCurrentEventWords()
+    getCurrentEventWords(puzzleDate)
   ]);
   const wordList = [...seasonal, ...funFacts, ...currentEvents];
   const puzzle = generateDaily(seed, wordList);

--- a/tests/lib/topics.test.ts
+++ b/tests/lib/topics.test.ts
@@ -86,15 +86,13 @@ describe("getFunFactWords", () => {
 describe("getCurrentEventWords", () => {
   it("returns normalized WordEntry[]", async () => {
     mockFetch((url) => {
-      if (url.includes("metrics/pageviews")) {
+      if (url.includes("/feed/news")) {
         return Promise.resolve({
           ok: true,
-          json: async () => ({
-            items: [{ articles: [{ article: "Foo_Bar" }] }]
-          })
+          json: async () => ({ stories: [{ links: [{ title: "Foo Bar" }] }] })
         });
       }
-      if (url.includes("page/summary/Foo_Bar")) {
+      if (url.includes("page/summary/Foo%20Bar")) {
         return Promise.resolve({
           ok: true,
           json: async () => ({ extract: "Example summary" })
@@ -103,19 +101,19 @@ describe("getCurrentEventWords", () => {
       return Promise.reject(new Error("unknown url"));
     });
     const { getCurrentEventWords } = await import("../../lib/topics");
-    const result = await getCurrentEventWords();
+    const result = await getCurrentEventWords(new Date("2024-01-01"));
     expect(result).toEqual([{ answer: "FOOBAR", clue: "Example summary" }]);
   });
 
   it("returns [] on failure", async () => {
     mockFetch((url) => {
-      if (url.includes("metrics/pageviews")) {
+      if (url.includes("/feed/news")) {
         return Promise.resolve({ ok: false, status: 500 });
       }
       return Promise.resolve({ ok: true, json: async () => ({}) });
     });
     const { getCurrentEventWords } = await import("../../lib/topics");
-    const result = await getCurrentEventWords();
+    const result = await getCurrentEventWords(new Date("2024-01-01"));
     expect(result).toEqual([]);
   });
 });

--- a/tests/scripts/generateDaily.test.ts
+++ b/tests/scripts/generateDaily.test.ts
@@ -42,6 +42,8 @@ describe('generateDaily script', () => {
     expect(puzzle.id).toBe('2024-01-02:seasonal,funFacts,currentEvents');
     expect(puzzle.title).toBe('Daily Placeholder');
     expect(puzzle.cells).toHaveLength(225);
+    expect(seasonalMock).toHaveBeenCalledWith(new Date('2024-01-02T00:00:00Z'));
+    expect(currentMock).toHaveBeenCalledWith(new Date('2024-01-02T00:00:00Z'));
 
     process.chdir(originalCwd);
   });


### PR DESCRIPTION
## Summary
- Replace Wikipedia pageview metrics with news feed in `getCurrentEventWords` and cache by puzzle date
- Pass puzzle date into `getCurrentEventWords` in daily puzzle script
- Add tests for news feed parsing and failure fallbacks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bb026f440832cb489e0b4e6ac5320