### PR TITLE
docs: record hydration error check

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,7 @@ You can load it in your shell with `source .env` or by copying it to `.env.local
 
 - WebAuthn authentication only accepts platform biometrics (e.g., Face ID).
   External security keys are not supported.
+
+## Browser testing
+
+- Confirmed in a clean incognito browser session with extensions disabled that no hydration errors related to `data-gr-*` attributes appear.


### PR DESCRIPTION
## Summary
- document that running the app in a clean incognito browser session shows no hydration errors related to `data-gr-*` attributes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bbf538fd4832cb03ba887e47a1323