### PR TITLE
Add development-only script to remove Grammarly attributes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css'
 import type { Metadata } from 'next'
+import Script from 'next/script'
 
 export const metadata: Metadata = {
   title: 'Crossed with Friends — Demo',
@@ -9,6 +10,13 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
+      <head>
+        {process.env.NODE_ENV !== 'production' && (
+          <Script id="strip-grammarly" strategy="beforeInteractive">
+            {`document.body.removeAttribute('data-new-gr-c-s-check-loaded'); document.body.removeAttribute('data-gr-ext-installed');`}
+          </Script>
+        )}
+      </head>
       <body className="min-h-screen antialiased">
         <div className="mx-auto max-w-md">{children}</div>
       </body>


### PR DESCRIPTION
## Summary
- import `Script` and inject dev-only script removing Grammarly flags from `document.body`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cc2db3fc0832cbcd740617b61647c