### PR TITLE
Add clue sanitization and tests

### DIFF
--- a/__tests__/clueClean.test.ts
+++ b/__tests__/clueClean.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { cleanClue } from '../lib/clueClean';
+
+describe('cleanClue', () => {
+  it('decodes HTML entities', () => {
+    expect(cleanClue('Fish &amp; Chips &#039;sides&#039;')).toBe("Fish & Chips 'sides'");
+  });
+  it('removes HTML tags', () => {
+    expect(cleanClue('Solve <b>this</b> clue')).toBe('Solve this clue');
+  });
+  it('strips URLs', () => {
+    expect(cleanClue('Visit https://example.com for more')).toBe('Visit for more');
+  });
+  it('removes enumeration in parentheses', () => {
+    expect(cleanClue('Alpha beta (5,3)')).toBe('Alpha beta');
+  });
+});

--- a/lib/clueClean.ts
+++ b/lib/clueClean.ts
@@ -1,0 +1,28 @@
+export function cleanClue(raw: string): string {
+  if (!raw) return '';
+  const entityMap: Record<string, string> = {
+    amp: '&',
+    lt: '<',
+    gt: '>',
+    quot: '"',
+    apos: "'",
+    nbsp: ' ',
+    rsquo: '’',
+    lsquo: '‘',
+    ldquo: '“',
+    rdquo: '”',
+    eacute: 'é'
+  };
+  let s = raw.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (m, p1) => {
+    if (p1[0] === '#') {
+      const code = p1[1].toLowerCase() === 'x' ? parseInt(p1.slice(2), 16) : parseInt(p1.slice(1), 10);
+      if (!isNaN(code)) return String.fromCodePoint(code);
+      return m;
+    }
+    return entityMap[p1] ?? m;
+  });
+  s = s.replace(/<[^>]*>/g, ' ');
+  s = s.replace(/https?:\/\/\S+|www\.\S+/gi, ' ');
+  s = s.replace(/\(\s*\d+(?:[\s,\-]*\d+)*\s*\)/g, ' ');
+  return s.replace(/\s+/g, ' ').trim();
+}

--- a/lib/puzzle.ts
+++ b/lib/puzzle.ts
@@ -1,3 +1,5 @@
+import { cleanClue } from './clueClean';
+
 export type Cell = {
   row: number;
   col: number;
@@ -64,7 +66,7 @@ export function generateDaily(seed: string, wordList: WordEntry[] = []): Puzzle 
             const ch = ans[i] ?? '';
             get(r,c+i).answer = ch;
           }
-          const clue = entry?.clue ?? `Across ${num}`;
+          const clue = cleanClue(entry?.clue ?? `Across ${num}`);
           across.push({number:num,text:clue,length:len});
         }
         if (startDown){
@@ -75,7 +77,7 @@ export function generateDaily(seed: string, wordList: WordEntry[] = []): Puzzle 
             const ch = ans[i] ?? get(r+i,c).answer;
             if (ch) get(r+i,c).answer = ch;
           }
-          const clue = entry?.clue ?? `Down ${num}`;
+          const clue = cleanClue(entry?.clue ?? `Down ${num}`);
           down.push({number:num,text:clue,length:len});
         }
         num++;
@@ -113,7 +115,7 @@ export async function loadDemoFromFile(): Promise<Puzzle> {
   const normalizeClues = (arr: any[]): Clue[] =>
     (arr ?? []).map((c: any) => ({
       number: Number(c.number),
-      text: coerceClueText(c.text),
+      text: cleanClue(coerceClueText(c.text)),
       length: Number(c.length),
     }));
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   test: {
     include: [
       'tests/**/*.test.ts',
+      '__tests__/**/*.test.ts',
     ],
     environment: 'jsdom',
   },


### PR DESCRIPTION
## Summary
- add `cleanClue` utility to decode entities, strip HTML/URLs/enumerations, and normalize whitespace
- sanitize clues in puzzle generation and topic word sources
- add unit tests for clue cleaning and configure Vitest to run them

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ccab3ae3c832cab1679887cee1b0e