### PR TITLE
Add puzzle validation for daily generator

### DIFF
--- a/__tests__/validatePuzzle.test.ts
+++ b/__tests__/validatePuzzle.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect } from 'vitest';
+import { validatePuzzle } from '../lib/validatePuzzle';
+import { generateDaily } from '../lib/puzzle';
+import type { Puzzle, Cell, Clue } from '../lib/puzzle';
+import { findSlots } from '../lib/slotFinder';
+
+describe('validatePuzzle', () => {
+  test('valid puzzle passes', () => {
+    const size = 15;
+    const cells: Cell[] = [];
+    for (let r = 0; r < size; r++) {
+      for (let c = 0; c < size; c++) {
+        cells.push({
+          row: r,
+          col: c,
+          isBlack: false,
+          answer: 'A',
+          clueNumber: null,
+          userInput: '',
+          isSelected: false,
+        });
+      }
+    }
+    const across: Clue[] = Array.from({ length: size }, (_, i) => ({
+      number: i + 1,
+      text: 'Row clue',
+      length: size,
+      enumeration: `(${size})`,
+    }));
+    const down: Clue[] = Array.from({ length: size }, (_, i) => ({
+      number: i + 1,
+      text: 'Col clue',
+      length: size,
+      enumeration: `(${size})`,
+    }));
+    const puzzle: Puzzle = {
+      id: 'test',
+      title: 'Valid',
+      theme: '',
+      across,
+      down,
+      cells,
+    };
+    expect(validatePuzzle(puzzle)).toEqual([]);
+  });
+
+  test('fails when not 225 cells', () => {
+    const puzzle = generateDaily('seed');
+    puzzle.cells.pop();
+    const errors = validatePuzzle(puzzle);
+    expect(errors.some((e) => e.includes('225'))).toBe(true);
+  });
+
+  test('detects clue and answer issues', () => {
+    const puzzle = generateDaily('seed');
+    // mismatched clue length and dirty clue
+    puzzle.across[0].length += 1;
+    puzzle.across[0].text = '<b>bad</b> clue http://example.com';
+    // compute first across slot to alter answer
+    const size = 15;
+    const grid: string[] = [];
+    for (let r = 0; r < size; r++) {
+      let row = '';
+      for (let c = 0; c < size; c++) {
+        row += puzzle.cells[r * size + c].isBlack ? '#' : '.';
+      }
+      grid.push(row);
+    }
+    const slot = findSlots(grid).across[0];
+    for (let i = 0; i < slot.length; i++) {
+      puzzle.cells[slot.row * size + slot.col + i].answer = i === 0 ? 'A' : '1';
+    }
+    const errors = validatePuzzle(puzzle);
+    expect(errors.some((e) => e.includes('clue') && e.includes('length'))).toBe(true);
+    expect(errors.some((e) => e.includes('not allowed'))).toBe(true);
+    expect(errors.some((e) => e.includes('not clean'))).toBe(true);
+  });
+
+  test('fails symmetry check', () => {
+    const puzzle = generateDaily('seed');
+    const size = 15;
+    const idx = 0;
+    const symIdx = size * size - 1;
+    puzzle.cells[idx].isBlack = !puzzle.cells[symIdx].isBlack;
+    const errors = validatePuzzle(puzzle, { checkSymmetry: true });
+    expect(errors.some((e) => e.includes('not symmetric'))).toBe(true);
+  });
+});

--- a/lib/validatePuzzle.ts
+++ b/lib/validatePuzzle.ts
@@ -1,0 +1,89 @@
+import { Puzzle, Cell, Clue } from './puzzle';
+import { findSlots, Slot } from './slotFinder';
+import { isAnswerAllowed } from './answerPolicy';
+import { cleanClue } from './clueClean';
+
+export function validatePuzzle(puzzle: Puzzle, opts: { checkSymmetry?: boolean } = {}): string[] {
+  const errors: string[] = [];
+  const size = 15;
+
+  if (!puzzle.cells || puzzle.cells.length !== size * size) {
+    errors.push(`Puzzle must have ${size * size} cells, got ${puzzle.cells?.length ?? 0}`);
+    return errors;
+  }
+
+  const requiredFields: (keyof Cell)[] = [
+    'row',
+    'col',
+    'isBlack',
+    'answer',
+    'clueNumber',
+    'userInput',
+    'isSelected',
+  ];
+  puzzle.cells.forEach((cell, idx) => {
+    for (const f of requiredFields) {
+      if (cell[f] === undefined) {
+        errors.push(`Cell ${idx} missing field ${String(f)}`);
+      }
+    }
+  });
+
+  const grid: string[] = [];
+  for (let r = 0; r < size; r++) {
+    let row = '';
+    for (let c = 0; c < size; c++) {
+      row += puzzle.cells[r * size + c].isBlack ? '#' : '.';
+    }
+    grid.push(row);
+  }
+  const slots = findSlots(grid);
+
+  const checkClues = (clues: Clue[], slots: Slot[], dir: 'across' | 'down') => {
+    clues.forEach((clue, i) => {
+      const slot = slots[i];
+      if (!slot) {
+        errors.push(`${dir} clue ${clue.number} has no slot`);
+        return;
+      }
+      const letters: string[] = [];
+      for (let k = 0; k < slot.length; k++) {
+        const idx = dir === 'across'
+          ? slot.row * size + slot.col + k
+          : (slot.row + k) * size + slot.col;
+        letters.push(puzzle.cells[idx].answer);
+      }
+      const answer = letters.join('');
+      if (clue.length !== slot.length) {
+        errors.push(`${dir} clue ${clue.number} length ${clue.length} ≠ slot length ${slot.length}`);
+      }
+      if (answer.length !== slot.length) {
+        errors.push(`${dir} answer ${clue.number} length ${answer.length} ≠ slot length ${slot.length}`);
+      }
+      if (!isAnswerAllowed(answer)) {
+        errors.push(`${dir} answer ${clue.number} not allowed: ${answer}`);
+      }
+      if (cleanClue(clue.text) !== clue.text) {
+        errors.push(`${dir} clue ${clue.number} not clean`);
+      }
+    });
+  };
+
+  checkClues(puzzle.across, slots.across, 'across');
+  checkClues(puzzle.down, slots.down, 'down');
+
+  if (opts.checkSymmetry) {
+    for (let r = 0; r < size; r++) {
+      for (let c = 0; c < size; c++) {
+        const idx = r * size + c;
+        const symIdx = (size - 1 - r) * size + (size - 1 - c);
+        if (idx >= symIdx) continue;
+        if (puzzle.cells[idx].isBlack !== puzzle.cells[symIdx].isBlack) {
+          errors.push(`Cells (${r},${c}) and (${size - 1 - r},${size - 1 - c}) not symmetric`);
+        }
+      }
+    }
+  }
+
+  return errors;
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "start": "next start",
     "test": "vitest run",
     "lint": "eslint .",
-    "generate:daily": "tsx scripts/generateDaily.ts",
+    "gen:daily": "tsx scripts/genDaily.ts",
     "db:migrate": "prisma migrate deploy",
     "db:seed": "prisma db seed"
   },

--- a/scripts/genDaily.ts
+++ b/scripts/genDaily.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import { generateDaily } from '../lib/puzzle';
+import { validatePuzzle } from '../lib/validatePuzzle';
 import { getSeasonalWords, getFunFactWords, getCurrentEventWords } from '../lib/topics';
 import { yyyyMmDd } from '../utils/date';
 import { logInfo, logError } from '../utils/logger';
@@ -16,6 +17,11 @@ async function main() {
   ]);
   const wordList = [...seasonal, ...funFacts, ...currentEvents];
   const puzzle = generateDaily(seed, wordList);
+  const errors = validatePuzzle(puzzle, { checkSymmetry: true });
+  if (errors.length > 0) {
+    errors.forEach((err) => logError('puzzle_invalid', { error: err }));
+    process.exit(1);
+  }
 
   const puzzlesDir = path.join(process.cwd(), 'puzzles');
   try {

--- a/tests/api/generateDailyApi.test.ts
+++ b/tests/api/generateDailyApi.test.ts
@@ -29,10 +29,11 @@ describe('generateDaily and API integration', () => {
     process.chdir(tmpDir);
 
     vi.mock('../../lib/topics', () => mockTopics);
+    vi.mock('../../lib/validatePuzzle', () => ({ validatePuzzle: () => [] }));
 
     vi.setSystemTime(new Date('2024-01-01T23:59:00-08:00'));
 
-    await import('../../scripts/generateDaily');
+    await import('../../scripts/genDaily');
     vi.useRealTimers();
     await new Promise(r => setTimeout(r, 0));
 
@@ -48,9 +49,10 @@ describe('generateDaily and API integration', () => {
     vi.useFakeTimers();
     vi.resetModules();
     vi.mock('../../lib/topics', () => mockTopics);
+    vi.mock('../../lib/validatePuzzle', () => ({ validatePuzzle: () => [] }));
     vi.setSystemTime(new Date('2024-01-02T00:01:00-08:00'));
 
-    await import('../../scripts/generateDaily');
+    await import('../../scripts/genDaily');
     vi.useRealTimers();
     await new Promise(r => setTimeout(r, 0));
 

--- a/tests/scripts/generateDaily.test.ts
+++ b/tests/scripts/generateDaily.test.ts
@@ -12,6 +12,10 @@ vi.mock('../../lib/topics', () => ({
   getCurrentEventWords: currentMock,
 }));
 
+vi.mock('../../lib/validatePuzzle', () => ({
+  validatePuzzle: () => [],
+}));
+
 vi.mock('../../utils/date', () => ({
   yyyyMmDd: () => '2024-01-02',
 }));
@@ -26,6 +30,7 @@ describe('generateDaily script', () => {
     seasonalMock.mockResolvedValue([{ answer: 'APPLE', clue: 'a fruit' }]);
     funFactMock.mockResolvedValue([{ answer: 'BANANA', clue: 'yellow fruit' }]);
     currentMock.mockResolvedValue([{ answer: 'CARROT', clue: 'orange vegetable' }]);
+    vi.doMock('../../lib/validatePuzzle', () => ({ validatePuzzle: () => [] }));
 
     const fsMod = await import('fs');
     const fs = fsMod.promises;
@@ -33,7 +38,7 @@ describe('generateDaily script', () => {
     const originalCwd = process.cwd();
     process.chdir(tmpDir);
 
-    await import('../../scripts/generateDaily');
+    await import('../../scripts/genDaily');
     await new Promise((r) => setTimeout(r, 50));
 
     const filePath = path.join(tmpDir, 'puzzles', '2024-01-02.json');
@@ -53,6 +58,7 @@ describe('generateDaily script', () => {
     seasonalMock.mockRejectedValue(new Error('boom'));
     funFactMock.mockResolvedValue([]);
     currentMock.mockResolvedValue([]);
+    vi.doMock('../../lib/validatePuzzle', () => ({ validatePuzzle: () => [] }));
 
     const fsMod = await import('fs');
     const fs = fsMod.promises;
@@ -63,7 +69,7 @@ describe('generateDaily script', () => {
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    await import('../../scripts/generateDaily');
+    await import('../../scripts/genDaily');
     await new Promise((r) => setTimeout(r, 0));
 
     expect(exitSpy).toHaveBeenCalledWith(1);


### PR DESCRIPTION
## Summary
- implement comprehensive `validatePuzzle` enforcing grid structure, answer lengths, clue cleanliness, answer policy, and optional symmetry
- rename script to `genDaily.ts` and validate generated puzzles before saving
- add tests for valid and invalid puzzles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cd1c558cc832c908bb400b9852d94