### PR TITLE
Handle missing word entries in generateDaily

### DIFF
--- a/__tests__/validatePuzzle.test.ts
+++ b/__tests__/validatePuzzle.test.ts
@@ -1,7 +1,8 @@
 import { describe, test, expect } from 'vitest';
 import { validatePuzzle } from '../lib/validatePuzzle';
-import { generateDaily } from '../lib/puzzle';
+import { generateDaily, WordEntry } from '../lib/puzzle';
 import type { Puzzle, Cell, Clue } from '../lib/puzzle';
+import { largeWordList } from '../tests/helpers/wordList';
 import { findSlots } from '../lib/slotFinder';
 
 describe('validatePuzzle', () => {
@@ -45,14 +46,14 @@ describe('validatePuzzle', () => {
   });
 
   test('fails when not 225 cells', () => {
-    const puzzle = generateDaily('seed');
+    const puzzle = generateDaily('seed', largeWordList());
     puzzle.cells.pop();
     const errors = validatePuzzle(puzzle);
     expect(errors.some((e) => e.includes('225'))).toBe(true);
   });
 
   test('detects clue and answer issues', () => {
-    const puzzle = generateDaily('seed');
+    const puzzle = generateDaily('seed', largeWordList());
     // mismatched clue length and dirty clue
     puzzle.across[0].length += 1;
     puzzle.across[0].text = '<b>bad</b> clue http://example.com';
@@ -77,12 +78,21 @@ describe('validatePuzzle', () => {
   });
 
   test('fails symmetry check', () => {
-    const puzzle = generateDaily('seed');
+    const puzzle = generateDaily('seed', largeWordList());
     const size = 15;
     const idx = 0;
     const symIdx = size * size - 1;
     puzzle.cells[idx].isBlack = !puzzle.cells[symIdx].isBlack;
     const errors = validatePuzzle(puzzle, { checkSymmetry: true });
     expect(errors.some((e) => e.includes('not symmetric'))).toBe(true);
+  });
+
+  test('aborts when word list is insufficient', () => {
+    const shortList: WordEntry[] = [{ answer: 'OK', clue: 'ok' }];
+    expect(() => {
+      const puzzle = generateDaily('seed', shortList);
+      const errors = validatePuzzle(puzzle);
+      expect(errors.some((e) => e.includes('not allowed'))).toBe(false);
+    }).toThrow();
   });
 });

--- a/lib/puzzle.ts
+++ b/lib/puzzle.ts
@@ -98,11 +98,13 @@ export function generateDaily(seed: string, wordList: WordEntry[] = []): Puzzle 
       starts.forEach((slot) => {
         slot.number = num;
         const entry = takeEntry(slot.length);
-        const ans = entry?.answer ?? ''.padEnd(slot.length, ' ');
+        if (!entry) {
+          console.error(`No word entry for length ${slot.length}`);
+          throw new Error(`Missing word entry for length ${slot.length}`);
+        }
+        const ans = entry.answer;
         const enumeration = `(${slot.length})`;
-        const clueText = cleanClue(
-          entry?.clue ?? `${slot.direction === 'across' ? 'Across' : 'Down'} ${num}`,
-        );
+        const clueText = cleanClue(entry.clue);
         if (slot.direction === 'across') {
           for (let i = 0; i < slot.length; i++) {
             const ch = ans[i] ?? '';

--- a/tests/api/generateDailyApi.test.ts
+++ b/tests/api/generateDailyApi.test.ts
@@ -3,11 +3,12 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { tmpdir } from 'os';
 import { NextRequest } from 'next/server';
+import { largeWordList } from '../helpers/wordList';
 
 const mockTopics = {
-  getSeasonalWords: vi.fn().mockResolvedValue([{ answer: 'APPLE', clue: 'a fruit' }]),
-  getFunFactWords: vi.fn().mockResolvedValue([{ answer: 'BANANA', clue: 'yellow fruit' }]),
-  getCurrentEventWords: vi.fn().mockResolvedValue([{ answer: 'CARROT', clue: 'orange veg' }])
+  getSeasonalWords: vi.fn().mockResolvedValue(largeWordList()),
+  getFunFactWords: vi.fn().mockResolvedValue(largeWordList()),
+  getCurrentEventWords: vi.fn().mockResolvedValue(largeWordList())
 };
 
 async function readJson(file: string) {

--- a/tests/helpers/wordList.ts
+++ b/tests/helpers/wordList.ts
@@ -1,0 +1,15 @@
+import { WordEntry } from '../../lib/puzzle';
+
+// Generate a large list of allowable words covering lengths 2-15
+export function largeWordList(): WordEntry[] {
+  const list: WordEntry[] = [];
+  for (let len = 2; len <= 15; len++) {
+    for (let i = 0; i < 100; i++) {
+      const answer = len === 2
+        ? (i % 2 === 0 ? 'OK' : 'AX')
+        : String.fromCharCode(65 + (i % 26)).repeat(len);
+      list.push({ answer, clue: `clue-${len}-${i}` });
+    }
+  }
+  return list;
+}

--- a/tests/lib/puzzle.test.ts
+++ b/tests/lib/puzzle.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
 import { generateDaily, coordsToIndex, loadDemoFromFile, WordEntry } from '../../lib/puzzle';
+import { largeWordList } from '../helpers/wordList';
 
 describe('generateDaily', () => {
   it('rejects answers whose length does not match a slot', () => {
     const wordList: WordEntry[] = [
-      { answer: 'ABC', clue: 'skip' },
+      { answer: 'ABCDEFGHIJKLMNOP', clue: 'skip' },
       { answer: 'OK', clue: 'fit' },
+      ...largeWordList(),
     ];
     const puzzle = generateDaily('test', wordList);
     const allClues = [...puzzle.across, ...puzzle.down].map((c) => c.text);

--- a/tests/scripts/generateDaily.test.ts
+++ b/tests/scripts/generateDaily.test.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { tmpdir } from 'os';
 import { describe, test, expect, vi, afterEach } from 'vitest';
+import { largeWordList } from '../helpers/wordList';
 
 const seasonalMock = vi.fn();
 const funFactMock = vi.fn();
@@ -27,9 +28,9 @@ afterEach(() => {
 describe('generateDaily script', () => {
   test('writes puzzle file with expected metadata', async () => {
     vi.resetModules();
-    seasonalMock.mockResolvedValue([{ answer: 'APPLE', clue: 'a fruit' }]);
-    funFactMock.mockResolvedValue([{ answer: 'BANANA', clue: 'yellow fruit' }]);
-    currentMock.mockResolvedValue([{ answer: 'CARROT', clue: 'orange vegetable' }]);
+    seasonalMock.mockResolvedValue(largeWordList());
+    funFactMock.mockResolvedValue(largeWordList());
+    currentMock.mockResolvedValue(largeWordList());
     vi.doMock('../../lib/validatePuzzle', () => ({ validatePuzzle: () => [] }));
 
     const fsMod = await import('fs');


### PR DESCRIPTION
## Summary
- abort puzzle generation when a slot can't be filled, logging the missing length
- expand test harnesses with large word list helper
- test that puzzle generation fails on short lists and integration pieces succeed

## Testing
- `npm test __tests__/validatePuzzle.test.ts tests/lib/puzzle.test.ts tests/scripts/generateDaily.test.ts tests/api/generateDailyApi.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689cd90cdcac832c9bd4a63d0e0cd870