### PR TITLE
feat: add hero placement planner

### DIFF
--- a/__tests__/heroPlacement.test.ts
+++ b/__tests__/heroPlacement.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { planHeroPlacements } from '../lib/heroPlacement';
+
+describe('planHeroPlacements', () => {
+  it('handles odd counts with central placement and paired rows', () => {
+    const terms = ['odysseus', 'hercules', 'achilles', 'theseus', 'perseus'];
+    const placements = planHeroPlacements(terms);
+    expect(placements).toEqual([
+      { term: 'ODYSSEUS', row: 7, col: 3, dir: 'across' },
+      { term: 'HERCULES', row: 5, col: 3, dir: 'across' },
+      { term: 'ACHILLES', row: 9, col: 3, dir: 'across' },
+      { term: 'THESEUS', row: 3, col: 4, dir: 'across' },
+      { term: 'PERSEUS', row: 11, col: 4, dir: 'across' },
+    ]);
+  });
+
+  it('handles even counts with symmetric pairs', () => {
+    const terms = ['hercules', 'achilles', 'theseus', 'perseus'];
+    const placements = planHeroPlacements(terms);
+    expect(placements).toEqual([
+      { term: 'HERCULES', row: 6, col: 3, dir: 'across' },
+      { term: 'ACHILLES', row: 8, col: 3, dir: 'across' },
+      { term: 'THESEUS', row: 4, col: 4, dir: 'across' },
+      { term: 'PERSEUS', row: 10, col: 4, dir: 'across' },
+    ]);
+  });
+});

--- a/lib/heroPlacement.ts
+++ b/lib/heroPlacement.ts
@@ -1,0 +1,41 @@
+export type Placement = { term: string; row: number; col: number; dir: 'across' | 'down' };
+
+export function planHeroPlacements(heroTerms: string[]): Placement[] {
+  const size = 15;
+  const center = Math.floor(size / 2); // 7 for size 15
+  const terms = heroTerms.map((t) => t.toUpperCase()).sort((a, b) => b.length - a.length);
+  const placements: Placement[] = [];
+  const remaining = [...terms];
+
+  const hasCenter = remaining.length % 2 === 1;
+  if (hasCenter) {
+    const term = remaining.shift()!;
+    const col = Math.floor((size - term.length) / 2);
+    placements.push({ term, row: center, col, dir: 'across' });
+  }
+
+  for (let i = 0; i < remaining.length; i += 2) {
+    const topTerm = remaining[i];
+    const bottomTerm = remaining[i + 1];
+    const pairIndex = i / 2;
+    let topRow: number;
+    let bottomRow: number;
+    if (hasCenter) {
+      topRow = center - 2 * (pairIndex + 1);
+      bottomRow = center + 2 * (pairIndex + 1);
+    } else {
+      topRow = center - (1 + 2 * pairIndex);
+      bottomRow = center + (1 + 2 * pairIndex);
+    }
+    if (topTerm) {
+      const colTop = Math.floor((size - topTerm.length) / 2);
+      placements.push({ term: topTerm, row: topRow, col: colTop, dir: 'across' });
+    }
+    if (bottomTerm) {
+      const colBottom = Math.floor((size - bottomTerm.length) / 2);
+      placements.push({ term: bottomTerm, row: bottomRow, col: colBottom, dir: 'across' });
+    }
+  }
+
+  return placements;
+}


### PR DESCRIPTION
## Summary
- add hero placement planning utility
- cover hero placement logic with unit tests

## Testing
- `npm test`
- `npm run lint` (warnings)


------
https://chatgpt.com/codex/tasks/task_e_689ceb88905c832c8b4d883a95c26f8f