### PR TITLE
test: add hero placement symmetry test

### DIFF
--- a/tests/lib/heroPlacement.test.ts
+++ b/tests/lib/heroPlacement.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { planHeroPlacements } from '../../lib/heroPlacement';
+
+describe('planHeroPlacements', () => {
+  it('places a central hero and symmetric pairs', () => {
+    const heroes = ['CAPTAINMARVEL', 'BLACKWIDOW', 'SPIDERMAN', 'IRONMAN', 'THOR'];
+    const placements = planHeroPlacements(heroes);
+    expect(placements).toEqual([
+      { term: 'CAPTAINMARVEL', row: 7, col: 1, dir: 'across' },
+      { term: 'BLACKWIDOW', row: 5, col: 2, dir: 'across' },
+      { term: 'SPIDERMAN', row: 9, col: 3, dir: 'across' },
+      { term: 'IRONMAN', row: 3, col: 4, dir: 'across' },
+      { term: 'THOR', row: 11, col: 5, dir: 'across' },
+    ]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add hero placement test verifying central hero and symmetric offsets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cecd699d4832cb89e2ac5fb9a967a