### PR TITLE
feat: allow hero terms in daily generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,17 @@ You can load it in your shell with `source .env` or by copying it to `.env.local
 ## Puzzle quality gate
 
 Daily puzzles are produced with a deterministic generation pipeline.
-Run the generator to build the puzzle for today:
+Run the generator to build the puzzle for today. You can optionally supply
+"hero" terms to pin in the grid:
 
 ```bash
-pnpm gen:daily
+pnpm gen:daily [hero terms...]
+
+# example
+pnpm gen:daily "captain marvel" "black widow"
 ```
+
+If no hero terms are provided, a default set is used.
 
 The script assembles word lists, creates a puzzle seeded by the date,
 and then runs `validatePuzzle` to enforce structural rules. Validators
@@ -55,10 +61,10 @@ pnpm lint
 
 ## Project tips
 
-- Generate the daily puzzle data locally with:
+- Generate the daily puzzle data locally (optionally providing hero terms):
 
   ```bash
-  pnpm gen:daily
+  pnpm gen:daily [hero terms...]
   ```
 
 - Run the test suite with:

--- a/scripts/genDaily.ts
+++ b/scripts/genDaily.ts
@@ -6,6 +6,8 @@ import { getSeasonalWords, getFunFactWords, getCurrentEventWords } from '../lib/
 import { yyyyMmDd } from '../utils/date';
 import { logInfo, logError } from '../utils/logger';
 
+const defaultHeroTerms = ['CAPTAINMARVEL', 'BLACKWIDOW', 'SPIDERMAN', 'IRONMAN', 'THOR'];
+
 async function main() {
   const date = yyyyMmDd();
   const seed = `${date}:seasonal,funFacts,currentEvents`;
@@ -16,7 +18,8 @@ async function main() {
     getCurrentEventWords(puzzleDate)
   ]);
   const wordList = [...seasonal, ...funFacts, ...currentEvents];
-  const puzzle = generateDaily(seed, wordList);
+  const heroTerms = process.argv.slice(2);
+  const puzzle = generateDaily(seed, wordList, heroTerms.length > 0 ? heroTerms : defaultHeroTerms);
   const errors = validatePuzzle(puzzle, { checkSymmetry: true });
   if (errors.length > 0) {
     errors.forEach((err) => logError('puzzle_invalid', { error: err }));


### PR DESCRIPTION
## Summary
- allow passing hero terms via CLI or default list in `genDaily`
- document hero term usage for `pnpm gen:daily`

## Testing
- `npm test` *(fails: Unable to read puzzle file)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689e0fe944c0832ca88e40ec41442c91