### PR TITLE
Add fallback words for daily generation

### DIFF
--- a/data/fallbackWords.json
+++ b/data/fallbackWords.json
@@ -1,0 +1,16 @@
+[
+  { "answer": "ON", "clue": "Not off" },
+  { "answer": "CAT", "clue": "Feline pet" },
+  { "answer": "DOOR", "clue": "Entryway barrier" },
+  { "answer": "APPLE", "clue": "Fruit in a pie" },
+  { "answer": "ORANGE", "clue": "Citrus fruit" },
+  { "answer": "PICTURE", "clue": "Framed image" },
+  { "answer": "COMPUTER", "clue": "Digital device" },
+  { "answer": "NOTEBOOKS", "clue": "Portable computers" },
+  { "answer": "STRAWBERRY", "clue": "Red berry" },
+  { "answer": "COUNTRYSIDE", "clue": "Rural area" },
+  { "answer": "RELATIONSHIP", "clue": "Connection between people" },
+  { "answer": "UNDERSTANDING", "clue": "Comprehension" },
+  { "answer": "RESPONSIBILITY", "clue": "Sense of duty" },
+  { "answer": "CONGRATULATIONS", "clue": "Words of praise" }
+]


### PR DESCRIPTION
## Summary
- add static fallback word list for lengths 2-15
- ensure daily generation supplements missing lengths with fallback words

## Testing
- `npm test` *(fails: Missing word entry for certain lengths and API failures)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e186206e0832c9d37ac78157da5ad