### PR TITLE
refactor: centralize grid symmetry

### DIFF
--- a/__tests__/validatePuzzle.test.ts
+++ b/__tests__/validatePuzzle.test.ts
@@ -4,6 +4,7 @@ import { generateDaily, WordEntry } from '../lib/puzzle';
 import type { Puzzle, Cell, Clue } from '../lib/puzzle';
 import { largeWordList } from '../tests/helpers/wordList';
 import { findSlots } from '../lib/slotFinder';
+import { symCell } from '../grid/symmetry';
 
 describe('validatePuzzle', () => {
   test('valid puzzle passes', () => {
@@ -81,7 +82,8 @@ describe('validatePuzzle', () => {
     const puzzle = generateDaily('seed', largeWordList(), [], undefined, { allow2: true });
     const size = 15;
     const idx = 0;
-    const symIdx = size * size - 1;
+    const sym = symCell(0, 0, size);
+    const symIdx = sym.row * size + sym.col;
     puzzle.cells[idx].isBlack = !puzzle.cells[symIdx].isBlack;
     const errors = validatePuzzle(puzzle, { checkSymmetry: true, allow2: true });
     expect(errors.some((e) => e.includes('not symmetric'))).toBe(true);

--- a/grid/symmetry.ts
+++ b/grid/symmetry.ts
@@ -1,0 +1,2 @@
+export { symCell, setBlack } from "../src/grid/symmetry";
+

--- a/lib/puzzle.ts
+++ b/lib/puzzle.ts
@@ -2,6 +2,7 @@ import { cleanClue } from './clueClean';
 import { findSlots, Slot } from './slotFinder';
 import { planHeroPlacements } from './heroPlacement';
 import { isValidFill } from '@/utils/validateWord';
+import { setBlack } from '@/grid/symmetry';
 
 export type Cell = {
   row: number;
@@ -47,7 +48,7 @@ export function generateDaily(
   for (let r=0;r<size;r++){
     for (let c=0;c<size;c++){
       const cond = ((r+c+hash(seed))%5===0) || ((r%7===0)&&(c%4===0));
-      if (cond){ blocks.add(`${r}_${c}`); blocks.add(`${size-1-r}_${size-1-c}`); }
+      if (cond){ setBlack(blocks, r, c, size); }
     }
   }
   for (let r=0;r<size;r++){

--- a/lib/validatePuzzle.ts
+++ b/lib/validatePuzzle.ts
@@ -2,6 +2,7 @@ import { Puzzle, Cell, Clue } from './puzzle';
 import { findSlots, Slot } from './slotFinder';
 import { cleanClue } from './clueClean';
 import { isValidFill } from '@/utils/validateWord';
+import { symCell } from '@/grid/symmetry';
 
 export function validatePuzzle(
   puzzle: Puzzle,
@@ -79,10 +80,11 @@ export function validatePuzzle(
     for (let r = 0; r < size; r++) {
       for (let c = 0; c < size; c++) {
         const idx = r * size + c;
-        const symIdx = (size - 1 - r) * size + (size - 1 - c);
+        const sym = symCell(r, c, size);
+        const symIdx = sym.row * size + sym.col;
         if (idx >= symIdx) continue;
         if (puzzle.cells[idx].isBlack !== puzzle.cells[symIdx].isBlack) {
-          errors.push(`Cells (${r},${c}) and (${size - 1 - r},${size - 1 - c}) not symmetric`);
+          errors.push(`Cells (${r},${c}) and (${sym.row},${sym.col}) not symmetric`);
         }
       }
     }

--- a/src/grid/symmetry.ts
+++ b/src/grid/symmetry.ts
@@ -1,0 +1,9 @@
+export function symCell(row: number, col: number, size = 15) {
+  return { row: size - 1 - row, col: size - 1 - col };
+}
+
+export function setBlack(blocks: Set<string>, row: number, col: number, size = 15) {
+  blocks.add(`${row}_${col}`);
+  const sym = symCell(row, col, size);
+  blocks.add(`${sym.row}_${sym.col}`);
+}


### PR DESCRIPTION
## Summary
- introduce `symCell` and `setBlack` helpers for grid symmetry
- use `setBlack` for black cell placement and `symCell` for symmetry checks
- test symmetry via updated unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a35d009634832c8ca605749c2a54c0