### PR TITLE
feat: add grid validation preflight

### DIFF
--- a/lib/puzzle.ts
+++ b/lib/puzzle.ts
@@ -3,6 +3,7 @@ import { findSlots, Slot } from './slotFinder';
 import { planHeroPlacements } from './heroPlacement';
 import { isValidFill } from '@/utils/validateWord';
 import { setBlack } from '@/grid/symmetry';
+import { validateSymmetry, validateMinSlotLength } from '../src/validate/puzzle';
 
 export type Cell = {
   row: number;
@@ -56,6 +57,22 @@ export function generateDaily(
       const isBlack = blocks.has(`${r}_${c}`)
       cells.push({ row:r, col:c, isBlack, answer:'', clueNumber:null, userInput:'', isSelected:false })
     }
+  }
+
+  const boolGrid: boolean[][] = [];
+  for (let r = 0; r < size; r++) {
+    const row: boolean[] = [];
+    for (let c = 0; c < size; c++) {
+      row.push(blocks.has(`${r}_${c}`));
+    }
+    boolGrid.push(row);
+  }
+  if (!validateSymmetry(boolGrid)) {
+    throw new Error('grid_not_symmetric');
+  }
+  const shortSlots = validateMinSlotLength(boolGrid, opts.allow2 ? 2 : 3);
+  if (shortSlots.length > 0) {
+    throw new Error('slot_too_short');
   }
 
   // place hero terms before slot finding

--- a/src/validate/puzzle.ts
+++ b/src/validate/puzzle.ts
@@ -1,0 +1,59 @@
+export function validateSymmetry(grid: boolean[][]): boolean {
+  const size = grid.length;
+  for (let r = 0; r < size; r++) {
+    for (let c = 0; c < size; c++) {
+      if (grid[r][c] !== grid[size - 1 - r][size - 1 - c]) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+export function getSlotLengths(grid: boolean[][], orientation: 'across' | 'down'): number[] {
+  const size = grid.length;
+  const lengths: number[] = [];
+  if (orientation === 'across') {
+    for (let r = 0; r < size; r++) {
+      let len = 0;
+      for (let c = 0; c < size; c++) {
+        if (!grid[r][c]) {
+          len++;
+        }
+        if (grid[r][c]) {
+          if (len > 1) lengths.push(len);
+          len = 0;
+        } else if (c === size - 1) {
+          if (len > 1) lengths.push(len);
+          len = 0;
+        }
+      }
+    }
+  } else {
+    for (let c = 0; c < size; c++) {
+      let len = 0;
+      for (let r = 0; r < size; r++) {
+        if (!grid[r][c]) {
+          len++;
+        }
+        if (grid[r][c]) {
+          if (len > 1) lengths.push(len);
+          len = 0;
+        } else if (r === size - 1) {
+          if (len > 1) lengths.push(len);
+          len = 0;
+        }
+      }
+    }
+  }
+  return lengths;
+}
+
+export function validateMinSlotLength(grid: boolean[][], min: number): number[] {
+  const lengths = [
+    ...getSlotLengths(grid, 'across'),
+    ...getSlotLengths(grid, 'down'),
+  ];
+  return lengths.filter((len) => len < min);
+}
+

--- a/tests/api/generateDailyApi.test.ts
+++ b/tests/api/generateDailyApi.test.ts
@@ -31,6 +31,7 @@ describe('generateDaily and API integration', () => {
 
     vi.mock('../../lib/topics', () => mockTopics);
     vi.mock('../../lib/validatePuzzle', () => ({ validatePuzzle: () => [] }));
+    vi.mock('../../src/validate/puzzle', () => ({ validateSymmetry: () => true, validateMinSlotLength: () => [] }));
 
     vi.setSystemTime(new Date('2024-01-01T23:59:00-08:00'));
     process.argv.push('--allow2');
@@ -52,6 +53,7 @@ describe('generateDaily and API integration', () => {
     vi.resetModules();
     vi.mock('../../lib/topics', () => mockTopics);
     vi.mock('../../lib/validatePuzzle', () => ({ validatePuzzle: () => [] }));
+    vi.mock('../../src/validate/puzzle', () => ({ validateSymmetry: () => true, validateMinSlotLength: () => [] }));
     vi.setSystemTime(new Date('2024-01-02T00:01:00-08:00'));
     process.argv.push('--allow2');
     await import('../../scripts/genDaily');

--- a/tests/scripts/generateDaily.test.ts
+++ b/tests/scripts/generateDaily.test.ts
@@ -17,6 +17,11 @@ vi.mock('../../lib/validatePuzzle', () => ({
   validatePuzzle: () => [],
 }));
 
+vi.mock('../../src/validate/puzzle', () => ({
+  validateSymmetry: () => true,
+  validateMinSlotLength: () => [],
+}));
+
 vi.mock('../../utils/date', () => ({
   yyyyMmDd: () => '2024-01-02',
 }));
@@ -32,6 +37,7 @@ describe('generateDaily script', () => {
     funFactMock.mockResolvedValue(largeWordList());
     currentMock.mockResolvedValue(largeWordList());
     vi.doMock('../../lib/validatePuzzle', () => ({ validatePuzzle: () => [] }));
+    vi.doMock('../../src/validate/puzzle', () => ({ validateSymmetry: () => true, validateMinSlotLength: () => [] }));
 
     const fsMod = await import('fs');
     const fs = fsMod.promises;
@@ -62,6 +68,7 @@ describe('generateDaily script', () => {
     funFactMock.mockResolvedValue([]);
     currentMock.mockResolvedValue([]);
     vi.doMock('../../lib/validatePuzzle', () => ({ validatePuzzle: () => [] }));
+    vi.doMock('../../src/validate/puzzle', () => ({ validateSymmetry: () => true, validateMinSlotLength: () => [] }));
 
     const fsMod = await import('fs');
     const fs = fsMod.promises;


### PR DESCRIPTION
## Summary
- add puzzle validation helpers for symmetry and slot lengths
- run symmetry and slot length checks before generating daily puzzle
- validate grid inside puzzle generation to guard other entry points

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a35fcd0450832c802798aaccc7d75a