### PR TITLE
Add tests for fill validation and grid helpers

### DIFF
--- a/__tests__/symmetry.test.ts
+++ b/__tests__/symmetry.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { symCell, setBlack } from "../grid/symmetry";
+
+describe("symCell", () => {
+  it("returns rotational counterpart", () => {
+    expect(symCell(0, 0, 5)).toEqual({ row: 4, col: 4 });
+    expect(symCell(1, 3, 5)).toEqual({ row: 3, col: 1 });
+  });
+});
+
+describe("setBlack", () => {
+  it("adds both cell and its symmetric counterpart", () => {
+    const blocks = new Set<string>();
+    setBlack(blocks, 1, 2, 5);
+    expect(blocks.has("1_2")).toBe(true);
+    expect(blocks.has("3_2")).toBe(true);
+  });
+
+  it("handles center cell without duplication", () => {
+    const blocks = new Set<string>();
+    setBlack(blocks, 2, 2, 5);
+    expect(blocks.size).toBe(1);
+    expect(blocks.has("2_2")).toBe(true);
+  });
+});

--- a/__tests__/validateMinSlotLength.test.ts
+++ b/__tests__/validateMinSlotLength.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { validateMinSlotLength } from "../src/validate/puzzle";
+
+describe("validateMinSlotLength", () => {
+  it("flags grids containing 2-letter slots", () => {
+    const grid = [
+      [false, false, false],
+      [true, false, false],
+      [true, true, true],
+    ];
+    expect(validateMinSlotLength(grid, 3)).toEqual([2, 2, 2]);
+  });
+
+  it("allows grids without short slots", () => {
+    const grid = [
+      [false, false, false],
+      [false, false, false],
+      [false, false, false],
+    ];
+    expect(validateMinSlotLength(grid, 3)).toEqual([]);
+  });
+});

--- a/__tests__/validateWord.test.ts
+++ b/__tests__/validateWord.test.ts
@@ -2,16 +2,13 @@ import { describe, it, expect } from "vitest";
 import { isValidFill } from "@/utils/validateWord";
 
 describe("isValidFill", () => {
-  it("rejects answers with non-uppercase letters", () => {
+  it("rejects answers with non-A–Z characters", () => {
     expect(isValidFill("ok")).toBe(false);
     expect(isValidFill("A1")).toBe(false);
   });
 
-  it("rejects single-letter answers", () => {
+  it("rejects short words", () => {
     expect(isValidFill("A")).toBe(false);
-  });
-
-  it("rejects two-letter answers by default", () => {
     expect(isValidFill("OK")).toBe(false);
   });
 
@@ -21,11 +18,11 @@ describe("isValidFill", () => {
     expect(isValidFill("AA", { allow2: true })).toBe(true);
   });
 
-  it("rejects denylisted answers", () => {
+  it("rejects triple repeated letters", () => {
     expect(isValidFill("ZZZ")).toBe(false);
   });
 
-  it("allows other valid answers", () => {
+  it("accepts valid fills", () => {
     expect(isValidFill("GOOD")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- expand isValidFill tests for non-letter chars, short words, triple repeats, and valid entries
- add symmetry helper tests ensuring rotational counterparts are set
- cover validateMinSlotLength with grids having and lacking 2-letter slots

## Testing
- `npm test` *(fails: tests/auth/webauthn-login.test.ts timeout and socket error)*

------
https://chatgpt.com/codex/tasks/task_e_68a378f11364832c90831207d33f5e4f