### PR TITLE
Add structured logging for puzzle validator failures

### DIFF
--- a/src/utils/chooseAnswer.ts
+++ b/src/utils/chooseAnswer.ts
@@ -1,6 +1,6 @@
 import { isValidFill } from "./validateWord";
 import { getFallback } from "./getFallback";
-import { logInfo } from "@/utils/logger";
+import { logInfo, logError } from "@/utils/logger";
 import type { WordEntry } from "../../lib/puzzle";
 
 export function chooseAnswer(
@@ -23,5 +23,6 @@ export function chooseAnswer(
     logInfo("fallback_word_used", { length: len, answer: fb.answer });
     return fb;
   }
+  logError("choose_answer_failed", { length: len, letters: letters.join("") });
   return undefined;
 }


### PR DESCRIPTION
## Summary
- log errors when chooseAnswer fallback fails
- catch preflight validator exceptions and log structured puzzle_invalid errors

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a37fb04c54832c87011de4d218e923