### PR TITLE
Guard crossword grid with boolean symmetry helpers

### DIFF
--- a/__tests__/symmetry.test.ts
+++ b/__tests__/symmetry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { symCell, setBlack } from "../grid/symmetry";
+import { symCell, setBlackGuarded } from "../grid/symmetry";
 
 describe("symCell", () => {
   it("returns rotational counterpart", () => {
@@ -8,18 +8,28 @@ describe("symCell", () => {
   });
 });
 
-describe("setBlack", () => {
+describe("setBlackGuarded", () => {
+  const makeGrid = () => Array.from({ length: 5 }, () => Array(5).fill(false));
+
   it("adds both cell and its symmetric counterpart", () => {
-    const blocks = new Set<string>();
-    setBlack(blocks, 1, 2, 5);
-    expect(blocks.has("1_2")).toBe(true);
-    expect(blocks.has("3_2")).toBe(true);
+    const grid = makeGrid();
+    setBlackGuarded(grid, 0, 0, 2);
+    expect(grid[0][0]).toBe(true);
+    expect(grid[4][4]).toBe(true);
   });
 
   it("handles center cell without duplication", () => {
-    const blocks = new Set<string>();
-    setBlack(blocks, 2, 2, 5);
-    expect(blocks.size).toBe(1);
-    expect(blocks.has("2_2")).toBe(true);
+    const grid = makeGrid();
+    setBlackGuarded(grid, 2, 2, 2);
+    const count = grid.flat().filter(Boolean).length;
+    expect(count).toBe(1);
+    expect(grid[2][2]).toBe(true);
+  });
+
+  it("throws when a short slot would be created", () => {
+    const grid = makeGrid();
+    expect(() => setBlackGuarded(grid, 0, 1, 3)).toThrow(
+      "guard_rejected_black_at_0_1",
+    );
   });
 });

--- a/grid/symmetry.ts
+++ b/grid/symmetry.ts
@@ -1,2 +1,2 @@
-export { symCell, setBlack } from "../src/grid/symmetry";
+export { symCell, wouldCreateShortSlot, setBlackGuarded } from "../src/grid/symmetry";
 

--- a/lib/puzzle.ts
+++ b/lib/puzzle.ts
@@ -1,7 +1,7 @@
 import { cleanClue } from './clueClean';
 import { findSlots, Slot } from './slotFinder';
 import { planHeroPlacements } from './heroPlacement';
-import { setBlack } from '@/grid/symmetry';
+import { setBlackGuarded } from '@/grid/symmetry';
 import { validateSymmetry, validateMinSlotLength } from '../src/validate/puzzle';
 import { chooseAnswer } from '@/utils/chooseAnswer';
 
@@ -44,32 +44,30 @@ export function generateDaily(
 ): Puzzle {
   const size = 15;
   const cells: Cell[] = [];
-  const blocks = new Set<string>();
-  for (let r=0;r<size;r++){
-    for (let c=0;c<size;c++){
-      const cond = ((r+c+hash(seed))%5===0) || ((r%7===0)&&(c%4===0));
-      if (cond){ setBlack(blocks, r, c, size); }
-    }
-  }
-  for (let r=0;r<size;r++){
-    for (let c=0;c<size;c++){
-      const isBlack = blocks.has(`${r}_${c}`)
-      cells.push({ row:r, col:c, isBlack, answer:'', clueNumber:null, userInput:'', isSelected:false })
-    }
-  }
-
-  const boolGrid: boolean[][] = [];
+  const boolGrid: boolean[][] = Array.from({ length: size }, () => Array(size).fill(false));
+  const minLen = opts.allow2 ? 2 : 3;
   for (let r = 0; r < size; r++) {
-    const row: boolean[] = [];
     for (let c = 0; c < size; c++) {
-      row.push(blocks.has(`${r}_${c}`));
+      const cond = ((r + c + hash(seed)) % 5 === 0) || ((r % 7 === 0) && (c % 4 === 0));
+      if (cond) {
+        try {
+          setBlackGuarded(boolGrid, r, c, minLen);
+        } catch {
+          /* ignore rejected black */
+        }
+      }
     }
-    boolGrid.push(row);
+  }
+  for (let r = 0; r < size; r++) {
+    for (let c = 0; c < size; c++) {
+      const isBlack = boolGrid[r][c];
+      cells.push({ row: r, col: c, isBlack, answer: '', clueNumber: null, userInput: '', isSelected: false });
+    }
   }
   if (!validateSymmetry(boolGrid)) {
     throw new Error('grid_not_symmetric');
   }
-  const shortSlots = validateMinSlotLength(boolGrid, opts.allow2 ? 2 : 3);
+  const shortSlots = validateMinSlotLength(boolGrid, minLen);
   if (shortSlots.length > 0) {
     throw new Error('slot_too_short');
   }

--- a/src/grid/symmetry.ts
+++ b/src/grid/symmetry.ts
@@ -2,8 +2,60 @@ export function symCell(row: number, col: number, size = 15) {
   return { row: size - 1 - row, col: size - 1 - col };
 }
 
-export function setBlack(blocks: Set<string>, row: number, col: number, size = 15) {
-  blocks.add(`${row}_${col}`);
+function checkRuns(grid: boolean[][], row: number, col: number, minLen: number) {
+  const size = grid.length;
+  let len = 0;
+  for (let c = col - 1; c >= 0 && !grid[row][c]; c--) len++;
+  if (len > 0 && len < minLen) return true;
+  len = 0;
+  for (let c = col + 1; c < size && !grid[row][c]; c++) len++;
+  if (len > 0 && len < minLen) return true;
+  len = 0;
+  for (let r = row - 1; r >= 0 && !grid[r][col]; r--) len++;
+  if (len > 0 && len < minLen) return true;
+  len = 0;
+  for (let r = row + 1; r < size && !grid[r][col]; r++) len++;
+  if (len > 0 && len < minLen) return true;
+  return false;
+}
+
+export function wouldCreateShortSlot(
+  grid: boolean[][],
+  row: number,
+  col: number,
+  minLen: number,
+) {
+  const size = grid.length;
+  const cells = [{ row, col }];
   const sym = symCell(row, col, size);
-  blocks.add(`${sym.row}_${sym.col}`);
+  if (sym.row !== row || sym.col !== col) cells.push(sym);
+
+  const prev: boolean[] = [];
+  cells.forEach(({ row, col }, idx) => {
+    prev[idx] = grid[row][col];
+    grid[row][col] = true;
+  });
+
+  const result = cells.some(({ row, col }) => checkRuns(grid, row, col, minLen));
+
+  cells.forEach(({ row, col }, idx) => {
+    grid[row][col] = prev[idx];
+  });
+
+  return result;
+}
+
+export function setBlackGuarded(
+  grid: boolean[][],
+  row: number,
+  col: number,
+  minLen: number,
+) {
+  if (grid[row][col]) return;
+  if (wouldCreateShortSlot(grid, row, col, minLen)) {
+    throw new Error(`guard_rejected_black_at_${row}_${col}`);
+  }
+  const sym = symCell(row, col, grid.length);
+  grid[row][col] = true;
+  grid[sym.row][sym.col] = true;
 }


### PR DESCRIPTION
## Summary
- replace Set-based symmetry utilities with boolean grid operations
- add short-slot guard `setBlackGuarded` and supporting `wouldCreateShortSlot`
- update puzzle generation and daily script to use guarded grid
- expand symmetry tests for guard and center-cell cases

## Testing
- `npm test` *(fails: tests/chat/chat.unit.test.ts - Command failed: npx prisma migrate deploy)*

------
https://chatgpt.com/codex/tasks/task_e_68a38f765e04832c9c7e8f2fce746931