### PR TITLE
Refactor slot length validation to return detail

### DIFF
--- a/__tests__/validateMinSlotLength.test.ts
+++ b/__tests__/validateMinSlotLength.test.ts
@@ -8,7 +8,13 @@ describe("validateMinSlotLength", () => {
       [true, false, false],
       [true, true, true],
     ];
-    expect(validateMinSlotLength(grid, 3)).toEqual([2, 2, 2]);
+    expect(validateMinSlotLength(grid, 3)).toEqual({
+      type: 'across',
+      r: 1,
+      c0: 1,
+      c1: 2,
+      len: 2,
+    });
   });
 
   it("allows grids without short slots", () => {
@@ -17,6 +23,6 @@ describe("validateMinSlotLength", () => {
       [false, false, false],
       [false, false, false],
     ];
-    expect(validateMinSlotLength(grid, 3)).toEqual([]);
+    expect(validateMinSlotLength(grid, 3)).toBeNull();
   });
 });

--- a/lib/puzzle.ts
+++ b/lib/puzzle.ts
@@ -4,6 +4,7 @@ import { planHeroPlacements } from './heroPlacement';
 import { setBlackGuarded } from '@/grid/symmetry';
 import { validateSymmetry, validateMinSlotLength } from '../src/validate/puzzle';
 import { chooseAnswer } from '@/utils/chooseAnswer';
+import { logError } from '../utils/logger';
 
 export type Cell = {
   row: number;
@@ -67,9 +68,10 @@ export function generateDaily(
   if (!validateSymmetry(boolGrid)) {
     throw new Error('grid_not_symmetric');
   }
-  const shortSlots = validateMinSlotLength(boolGrid, minLen);
-  if (shortSlots.length > 0) {
-    throw new Error('slot_too_short');
+  const detail = validateMinSlotLength(boolGrid, minLen);
+  if (detail) {
+    logError('slot_too_short', { detail });
+    process.exit(1);
   }
 
   // place hero terms before slot finding

--- a/scripts/genDaily.ts
+++ b/scripts/genDaily.ts
@@ -97,9 +97,9 @@ async function main() {
       logError('grid_not_symmetric');
       process.exit(1);
     }
-    const shortSlots = validateMinSlotLength(grid, minLen);
-    if (shortSlots.length > 0) {
-      logError('slot_too_short', { lengths: shortSlots });
+    const detail = validateMinSlotLength(grid, minLen);
+    if (detail) {
+      logError('slot_too_short', { detail });
       process.exit(1);
     }
   } catch (err) {

--- a/src/validate/puzzle.ts
+++ b/src/validate/puzzle.ts
@@ -21,10 +21,10 @@ export function getSlotLengths(grid: boolean[][], orientation: 'across' | 'down'
           len++;
         }
         if (grid[r][c]) {
-          if (len > 1) lengths.push(len);
+          if (len > 0) lengths.push(len);
           len = 0;
         } else if (c === size - 1) {
-          if (len > 1) lengths.push(len);
+          if (len > 0) lengths.push(len);
           len = 0;
         }
       }
@@ -37,10 +37,10 @@ export function getSlotLengths(grid: boolean[][], orientation: 'across' | 'down'
           len++;
         }
         if (grid[r][c]) {
-          if (len > 1) lengths.push(len);
+          if (len > 0) lengths.push(len);
           len = 0;
         } else if (r === size - 1) {
-          if (len > 1) lengths.push(len);
+          if (len > 0) lengths.push(len);
           len = 0;
         }
       }
@@ -49,11 +49,63 @@ export function getSlotLengths(grid: boolean[][], orientation: 'across' | 'down'
   return lengths;
 }
 
-export function validateMinSlotLength(grid: boolean[][], min: number): number[] {
-  const lengths = [
-    ...getSlotLengths(grid, 'across'),
-    ...getSlotLengths(grid, 'down'),
-  ];
-  return lengths.filter((len) => len < min);
+export type ShortSlotDetail = {
+  type: 'across' | 'down';
+  r: number;
+  c0: number;
+  c1: number;
+  len: number;
+};
+
+function findFirstShortSlot(grid: boolean[][], min: number): ShortSlotDetail | null {
+  const size = grid.length;
+  // Scan across
+  for (let r = 0; r < size; r++) {
+    let len = 0;
+    let start = -1;
+    for (let c = 0; c < size; c++) {
+      if (!grid[r][c]) {
+        if (len === 0) start = c;
+        len++;
+      }
+      if (grid[r][c] || c === size - 1) {
+        const end = grid[r][c] ? c - 1 : c;
+        if (len > 0) {
+          if (len < min) return { type: 'across', r, c0: start, c1: end, len };
+        }
+        len = 0;
+        start = -1;
+      }
+    }
+  }
+
+  // Scan down
+  for (let c = 0; c < size; c++) {
+    let len = 0;
+    let start = -1;
+    for (let r = 0; r < size; r++) {
+      if (!grid[r][c]) {
+        if (len === 0) start = r;
+        len++;
+      }
+      if (grid[r][c] || r === size - 1) {
+        const end = grid[r][c] ? r - 1 : r;
+        if (len > 0) {
+          if (len < min) return { type: 'down', r: start, c0: c, c1: end, len };
+        }
+        len = 0;
+        start = -1;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function validateMinSlotLength(
+  grid: boolean[][],
+  min: number,
+): ShortSlotDetail | null {
+  return findFirstShortSlot(grid, min);
 }
 

--- a/tests/api/generateDailyApi.test.ts
+++ b/tests/api/generateDailyApi.test.ts
@@ -31,7 +31,7 @@ describe('generateDaily and API integration', () => {
 
     vi.mock('../../lib/topics', () => mockTopics);
     vi.mock('../../lib/validatePuzzle', () => ({ validatePuzzle: () => [] }));
-    vi.mock('../../src/validate/puzzle', () => ({ validateSymmetry: () => true, validateMinSlotLength: () => [] }));
+    vi.mock('../../src/validate/puzzle', () => ({ validateSymmetry: () => true, validateMinSlotLength: () => null }));
 
     vi.setSystemTime(new Date('2024-01-01T23:59:00-08:00'));
     process.argv.push('--allow2=true');
@@ -53,7 +53,7 @@ describe('generateDaily and API integration', () => {
     vi.resetModules();
     vi.mock('../../lib/topics', () => mockTopics);
     vi.mock('../../lib/validatePuzzle', () => ({ validatePuzzle: () => [] }));
-    vi.mock('../../src/validate/puzzle', () => ({ validateSymmetry: () => true, validateMinSlotLength: () => [] }));
+    vi.mock('../../src/validate/puzzle', () => ({ validateSymmetry: () => true, validateMinSlotLength: () => null }));
     vi.setSystemTime(new Date('2024-01-02T00:01:00-08:00'));
     process.argv.push('--allow2=true');
     await import('../../scripts/genDaily');

--- a/tests/scripts/generateDaily.test.ts
+++ b/tests/scripts/generateDaily.test.ts
@@ -19,7 +19,7 @@ vi.mock('../../lib/validatePuzzle', () => ({
 
 vi.mock('../../src/validate/puzzle', () => ({
   validateSymmetry: () => true,
-  validateMinSlotLength: () => [],
+  validateMinSlotLength: () => null,
 }));
 
 vi.mock('../../utils/date', () => ({
@@ -37,7 +37,7 @@ describe('generateDaily script', () => {
     funFactMock.mockResolvedValue(largeWordList());
     currentMock.mockResolvedValue(largeWordList());
     vi.doMock('../../lib/validatePuzzle', () => ({ validatePuzzle: () => [] }));
-    vi.doMock('../../src/validate/puzzle', () => ({ validateSymmetry: () => true, validateMinSlotLength: () => [] }));
+    vi.doMock('../../src/validate/puzzle', () => ({ validateSymmetry: () => true, validateMinSlotLength: () => null }));
 
     const fsMod = await import('fs');
     const fs = fsMod.promises;
@@ -68,7 +68,7 @@ describe('generateDaily script', () => {
     funFactMock.mockResolvedValue([]);
     currentMock.mockResolvedValue([]);
     vi.doMock('../../lib/validatePuzzle', () => ({ validatePuzzle: () => [] }));
-    vi.doMock('../../src/validate/puzzle', () => ({ validateSymmetry: () => true, validateMinSlotLength: () => [] }));
+    vi.doMock('../../src/validate/puzzle', () => ({ validateSymmetry: () => true, validateMinSlotLength: () => null }));
 
     const fsMod = await import('fs');
     const fs = fsMod.promises;


### PR DESCRIPTION
## Summary
- track every slot length in `getSlotLengths`
- add `findFirstShortSlot` and return detail from `validateMinSlotLength`
- standardize slot length checks in daily generator and puzzle library

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3930c9124832cab430888c908c64e