### PR TITLE
feat: add mask generator

### DIFF
--- a/grid/mask.ts
+++ b/grid/mask.ts
@@ -1,0 +1,1 @@
+export { buildMask } from "../src/grid/mask";

--- a/lib/puzzle.ts
+++ b/lib/puzzle.ts
@@ -1,7 +1,7 @@
 import { cleanClue } from './clueClean';
 import { findSlots, Slot } from './slotFinder';
 import { planHeroPlacements } from './heroPlacement';
-import { setBlackGuarded } from '@/grid/symmetry';
+import { buildMask } from '@/grid/mask';
 import { validateSymmetry, validateMinSlotLength } from '../src/validate/puzzle';
 import { chooseAnswer } from '@/utils/chooseAnswer';
 import { logError } from '../utils/logger';
@@ -32,33 +32,17 @@ export function coordsToIndex(row: number, col: number, size = 15) {
   return row * size + col;
 }
 
-function hash(s: string) {
-  let h = 2166136261; for (let i=0;i<s.length;i++){ h ^= s.charCodeAt(i); h = Math.imul(h, 16777619); }
-  return Math.abs(h>>>0) % 97;
-}
-
 export function generateDaily(
   seed: string,
   wordList: WordEntry[] = [],
   heroTerms: string[] = [],
   opts: { allow2?: boolean } = {},
+  mask?: boolean[][],
 ): Puzzle {
-  const size = 15;
+  const size = mask ? mask.length : 15;
   const cells: Cell[] = [];
-  const boolGrid: boolean[][] = Array.from({ length: size }, () => Array(size).fill(false));
   const minLen = opts.allow2 ? 2 : 3;
-  for (let r = 0; r < size; r++) {
-    for (let c = 0; c < size; c++) {
-      const cond = ((r + c + hash(seed)) % 5 === 0) || ((r % 7 === 0) && (c % 4 === 0));
-      if (cond) {
-        try {
-          setBlackGuarded(boolGrid, r, c, minLen);
-        } catch {
-          /* ignore rejected black */
-        }
-      }
-    }
-  }
+  const boolGrid = mask ?? buildMask(size, 36, 5000, minLen);
   for (let r = 0; r < size; r++) {
     for (let c = 0; c < size; c++) {
       const isBlack = boolGrid[r][c];

--- a/src/grid/mask.ts
+++ b/src/grid/mask.ts
@@ -1,0 +1,40 @@
+import { setBlackGuarded, symCell } from './symmetry';
+
+export function buildMask(
+  n = 15,
+  targetBlocks = 36,
+  maxAttempts = 5000,
+  minLen = 3,
+) {
+  const grid: boolean[][] = Array.from({ length: n }, () => Array(n).fill(false));
+  let placed = 0;
+  if (minLen === 2) {
+    try {
+      setBlackGuarded(grid, 0, 2, minLen);
+      placed += 2;
+    } catch {
+      // ignore pre-placement failure
+    }
+  }
+  let attempts = 0;
+  while (placed < targetBlocks && attempts < maxAttempts) {
+    attempts++;
+    const r = Math.floor(Math.random() * n);
+    const c = Math.floor(Math.random() * n);
+    try {
+      setBlackGuarded(grid, r, c, minLen);
+      const sym = symCell(r, c, n);
+      if (sym.row === r && sym.col === c) {
+        placed += 1;
+      } else {
+        placed += 2;
+      }
+    } catch {
+      // ignore placement failures
+    }
+  }
+  if (placed < targetBlocks) {
+    throw new Error(`mask_generation_failed: placed=${placed}, target=${targetBlocks}`);
+  }
+  return grid;
+}


### PR DESCRIPTION
## Summary
- add buildMask utility to programmatically construct symmetric block masks
- use buildMask for puzzle generation and daily puzzle script
- surface buildMask via grid/mask re-export

## Testing
- `npx vitest run tests/lib/puzzle.test.ts`
- `npx vitest run tests/groups/group.api.test.ts`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a39c51ce64832c9849c871df690dc0