### PR TITLE
Implement mask repair and integrate into puzzle generator

### DIFF
--- a/__tests__/repairMask.test.ts
+++ b/__tests__/repairMask.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { repairMask } from '../lib/repairMask';
+import { validateMinSlotLength } from '../src/validate/puzzle';
+import { symCell } from '../grid/symmetry';
+
+describe('repairMask', () => {
+  it('repairs asymmetric grids with short slots', () => {
+    const grid = [
+      [true, false, false],
+      [false, false, false],
+      [false, false, false],
+    ];
+    const repaired = repairMask(grid, 3);
+    expect(validateMinSlotLength(repaired, 3)).toBeNull();
+    const s = symCell(0, 0, repaired.length);
+    expect(repaired[0][0]).toBe(false);
+    expect(repaired[s.row][s.col]).toBe(false);
+  });
+
+  it('repairs short slots in symmetric grids', () => {
+    const grid = [
+      [false, false, false],
+      [true, false, true],
+      [false, false, false],
+    ];
+    const repaired = repairMask(grid, 3);
+    expect(validateMinSlotLength(repaired, 3)).toBeNull();
+    expect(repaired[1][0]).toBe(false);
+    expect(repaired[1][2]).toBe(false);
+  });
+
+  it('throws when repair fails', () => {
+    const grid = [
+      [false, false],
+      [false, false],
+    ];
+    expect(() => repairMask(grid, 3)).toThrow();
+  });
+});

--- a/lib/puzzle.ts
+++ b/lib/puzzle.ts
@@ -5,6 +5,7 @@ import { buildMask } from '@/grid/mask';
 import { validateSymmetry, validateMinSlotLength } from '../src/validate/puzzle';
 import { chooseAnswer } from '@/utils/chooseAnswer';
 import { logError } from '../utils/logger';
+import { repairMask } from './repairMask';
 
 export type Cell = {
   row: number;
@@ -42,7 +43,7 @@ export function generateDaily(
   const size = mask ? mask.length : 15;
   const cells: Cell[] = [];
   const minLen = opts.allow2 ? 2 : 3;
-  const boolGrid = mask ?? buildMask(size, 36, 5000, minLen);
+  const boolGrid = mask ? repairMask(mask, minLen) : buildMask(size, 36, 5000, minLen);
   for (let r = 0; r < size; r++) {
     for (let c = 0; c < size; c++) {
       const isBlack = boolGrid[r][c];

--- a/lib/repairMask.ts
+++ b/lib/repairMask.ts
@@ -1,0 +1,41 @@
+import { symCell } from '@/grid/symmetry';
+import { validateMinSlotLength } from '../src/validate/puzzle';
+
+export function repairMask(grid: boolean[][], minLen = 3, maxPasses = 50): boolean[][] {
+  let detail = validateMinSlotLength(grid, minLen);
+  let passes = 0;
+  const size = grid.length;
+  while (detail && passes < maxPasses) {
+    passes++;
+    let r: number | undefined;
+    let c: number | undefined;
+    if (detail.type === 'across') {
+      if (detail.c0 > 0 && grid[detail.r][detail.c0 - 1]) {
+        r = detail.r;
+        c = detail.c0 - 1;
+      } else if (detail.c1 < size - 1 && grid[detail.r][detail.c1 + 1]) {
+        r = detail.r;
+        c = detail.c1 + 1;
+      }
+    } else {
+      if (detail.r > 0 && grid[detail.r - 1][detail.c0]) {
+        r = detail.r - 1;
+        c = detail.c0;
+      } else if (detail.c1 < size - 1 && grid[detail.c1 + 1][detail.c0]) {
+        r = detail.c1 + 1;
+        c = detail.c0;
+      }
+    }
+    if (r === undefined || c === undefined) break;
+    const sym = symCell(r, c, size);
+    grid[r][c] = false;
+    grid[sym.row][sym.col] = false;
+    detail = validateMinSlotLength(grid, minLen);
+  }
+  if (detail) {
+    throw new Error('mask_repair_failed');
+  }
+  return grid;
+}
+
+export default repairMask;


### PR DESCRIPTION
## Summary
- add `repairMask` utility to fix asymmetric blocks and short slots by clearing offending cells and their symmetric partners
- run `repairMask` on provided masks before puzzle generation
- cover mask repair cases, including irreparable masks, with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a39fbedf50832cb79781b8f2d24537