### PR TITLE
Respect allow2 flag in slot-length validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ pnpm gen:daily "captain marvel" "black widow" --allow2=true
 ```
 
 If no hero terms are provided, a default set is used. Two-letter answers
-remain disallowed unless `--allow2=true` is specified.
+remain disallowed unless `--allow2=true` is specified. When allowing two-letter
+entries, slot-length validation is skipped.
 
-The script assembles word lists, creates a puzzle seeded by the date,
-and then runs `validatePuzzle` to enforce structural rules. Validators
-ensure every clue is normalized by `cleanClue`, answers obey the policy
-from `isValidFill`, and the grid passes symmetry and length checks.
+The script assembles word lists, creates a puzzle seeded by the date, and then
+runs `validatePuzzle` to enforce structural rules. Validators ensure every clue
+is normalized by `cleanClue`, answers obey the policy from `isValidFill`, and the
+grid passes symmetry and length checks (unless bypassed with `--allow2=true`).
 
 The answer policy draws from a deny list:
 

--- a/__tests__/repairMask.test.ts
+++ b/__tests__/repairMask.test.ts
@@ -29,6 +29,17 @@ describe('repairMask', () => {
     expect(repaired[1][2]).toBe(false);
   });
 
+  it('skips validation when allow2 is true', () => {
+    const grid = [
+      [true, false, false],
+      [false, false, false],
+      [false, false, false],
+    ];
+    const repaired = repairMask(grid, 3, 50, true);
+    expect(repaired).toBe(grid);
+    expect(validateMinSlotLength(repaired, 3)).not.toBeNull();
+  });
+
   it('throws when repair fails', () => {
     const grid = [
       [false, false],

--- a/lib/puzzle.ts
+++ b/lib/puzzle.ts
@@ -43,7 +43,9 @@ export function generateDaily(
   const size = mask ? mask.length : 15;
   const cells: Cell[] = [];
   const minLen = opts.allow2 ? 2 : 3;
-  const boolGrid = mask ? repairMask(mask, minLen) : buildMask(size, 36, 5000, minLen);
+  const boolGrid = mask
+    ? repairMask(mask, minLen, 50, opts.allow2)
+    : buildMask(size, 36, 5000, minLen);
   for (let r = 0; r < size; r++) {
     for (let c = 0; c < size; c++) {
       const isBlack = boolGrid[r][c];
@@ -53,10 +55,12 @@ export function generateDaily(
   if (!validateSymmetry(boolGrid)) {
     throw new Error('grid_not_symmetric');
   }
-  const detail = validateMinSlotLength(boolGrid, minLen);
-  if (detail) {
-    logError('slot_too_short', { detail });
-    process.exit(1);
+  if (!opts.allow2) {
+    const detail = validateMinSlotLength(boolGrid, minLen);
+    if (detail) {
+      logError('slot_too_short', { detail });
+      process.exit(1);
+    }
   }
 
   // place hero terms before slot finding

--- a/lib/repairMask.ts
+++ b/lib/repairMask.ts
@@ -1,7 +1,13 @@
 import { symCell } from '@/grid/symmetry';
 import { validateMinSlotLength } from '../src/validate/puzzle';
 
-export function repairMask(grid: boolean[][], minLen = 3, maxPasses = 50): boolean[][] {
+export function repairMask(
+  grid: boolean[][],
+  minLen = 3,
+  maxPasses = 50,
+  allow2 = false,
+): boolean[][] {
+  if (allow2) return grid;
   let detail = validateMinSlotLength(grid, minLen);
   let passes = 0;
   const size = grid.length;

--- a/scripts/genDaily.ts
+++ b/scripts/genDaily.ts
@@ -77,10 +77,12 @@ async function main() {
       logError('grid_not_symmetric');
       process.exit(1);
     }
-    const detail = validateMinSlotLength(grid, minLen);
-    if (detail) {
-      logError('slot_too_short', { detail });
-      process.exit(1);
+    if (!allow2) {
+      const detail = validateMinSlotLength(grid, minLen);
+      if (detail) {
+        logError('slot_too_short', { detail });
+        process.exit(1);
+      }
     }
   } catch (err) {
     logError('puzzle_invalid', { error: (err as Error).message });


### PR DESCRIPTION
## Summary
- Skip slot-length checks in daily puzzle generator when `--allow2` flag is enabled
- Honor `allow2` in `generateDaily` and `repairMask`, bypassing short slot validation
- Document bypass behavior in CLI README and add test coverage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3a394ec5c832cbd4515e1ac5df154