### PR TITLE
feat: add slot coverage validation

### DIFF
--- a/src/validate/coverage.ts
+++ b/src/validate/coverage.ts
@@ -1,0 +1,31 @@
+export type PoolsByLength = {
+  heroesByLen: Record<number, number>;
+  dictByLen: Record<number, number>;
+  fallbackByLen: Record<number, number>;
+};
+
+export function assertCoverage(requiredLens: number[], pools: PoolsByLength): void {
+  const requiredCount: Record<number, number> = {};
+  for (const len of requiredLens) {
+    requiredCount[len] = (requiredCount[len] || 0) + 1;
+  }
+
+  for (const [lenStr, needed] of Object.entries(requiredCount)) {
+    const len = Number(lenStr);
+    const heroes = pools.heroesByLen[len] || 0;
+    const dict = pools.dictByLen[len] || 0;
+    const fallback = pools.fallbackByLen[len] || 0;
+    const available = heroes + dict;
+    if (available >= needed) continue;
+    if (fallback > 0) continue;
+    throw {
+      message: 'puzzle_invalid',
+      error: 'slot_coverage',
+      detail: {
+        length: len,
+        required: needed,
+        available: { heroes, dict, fallback },
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add slot coverage validation helper
- verify candidate pools cover required slot lengths before solving

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4cc415118832cae33e6bf4186ec18