### PR TITLE
feat: seedable puzzle generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "clsx": "2.1.1",
         "next": "^15.4.6",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "seedrandom": "^3.0.5"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.4",
@@ -7650,6 +7651,12 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
+    },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
       "license": "MIT"
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "clsx": "2.1.1",
     "next": "^15.4.6",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "seedrandom": "^3.0.5"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.4",

--- a/src/grid/mask.ts
+++ b/src/grid/mask.ts
@@ -5,6 +5,7 @@ export function buildMask(
   targetBlocks = 36,
   maxAttempts = 5000,
   minLen = 3,
+  rng: () => number = Math.random,
 ) {
   const grid: boolean[][] = Array.from({ length: n }, () => Array(n).fill(false));
   let placed = 0;
@@ -19,8 +20,8 @@ export function buildMask(
   let attempts = 0;
   while (placed < targetBlocks && attempts < maxAttempts) {
     attempts++;
-    const r = Math.floor(Math.random() * n);
-    const c = Math.floor(Math.random() * n);
+    const r = Math.floor(rng() * n);
+    const c = Math.floor(rng() * n);
     try {
       setBlackGuarded(grid, r, c, minLen);
       const sym = symCell(r, c, n);

--- a/src/utils/getFallback.ts
+++ b/src/utils/getFallback.ts
@@ -11,12 +11,13 @@ const FALLBACK_WORDS: Record<number, string[]> = Object.fromEntries(
 export function getFallback(
   len: number,
   letters: string[] = [],
-  opts: { allow2?: boolean } = {},
+  opts: { allow2?: boolean; rng?: () => number } = {},
 ): string | null {
   const minLen = opts.allow2 ? 2 : 3;
   const candidates = (FALLBACK_WORDS[len] || []).filter(
     (w) => isValidFill(w, minLen) && letters.every((ch, i) => !ch || w[i] === ch),
   );
   if (candidates.length === 0) return null;
-  return candidates[Math.floor(Math.random() * candidates.length)];
+  const rand = opts.rng ?? Math.random;
+  return candidates[Math.floor(rand() * candidates.length)];
 }


### PR DESCRIPTION
## Summary
- use seedrandom to seed and reuse RNG in `generateDaily`
- drive grid masks and fallback selection from the seeded RNG
- shuffle candidate pools with RNG for deterministic puzzles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4f141a104832c9348cff308707893