### PR TITLE
Add word bank, slot length, and coverage utilities

### DIFF
--- a/__tests__/coverage.test.ts
+++ b/__tests__/coverage.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { validateCoverage } from '../lib/coverage';
+import type { WordBank } from '../lib/wordBank';
+
+describe('validateCoverage', () => {
+  it('reports missing lengths when bank is insufficient', () => {
+    const bank: WordBank = { 3: ['CAT', 'DOG'], 4: ['LION'] };
+    const slots = [3, 3, 4, 4];
+    expect(validateCoverage(slots, bank)).toEqual({
+      need: { 3: 2, 4: 2 },
+      missing: [4],
+    });
+  });
+
+  it('returns empty missing when bank covers slots and skips length 2', () => {
+    const bank: WordBank = { 3: ['CAT'] };
+    const slots = [2, 2, 3];
+    expect(validateCoverage(slots, bank)).toEqual({
+      need: { 3: 1 },
+      missing: [],
+    });
+  });
+});

--- a/__tests__/gridSlots.test.ts
+++ b/__tests__/gridSlots.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { getSlotLengths } from '../lib/gridSlots';
+import type { Cell } from '../lib/puzzle';
+
+describe('getSlotLengths', () => {
+  const makeGrid = (rows: string[]): Cell[][] =>
+    rows.map((row, r) =>
+      row.split('').map((ch, c) => ({
+        row: r,
+        col: c,
+        isBlack: ch === '#',
+        answer: '',
+        clueNumber: null,
+        userInput: '',
+        isSelected: false,
+      })),
+    );
+
+  it('computes horizontal and vertical slot lengths', () => {
+    const grid = makeGrid([
+      '##..#',
+      '...##',
+      '#....',
+      '##..#',
+      '..###',
+    ]);
+    const res = getSlotLengths(grid);
+    expect(res).toEqual({
+      horiz: [2, 2, 2, 3, 4],
+      vert: [2, 2, 4],
+      all: [2, 2, 2, 2, 2, 3, 4, 4],
+    });
+  });
+
+  it('handles grids with no slots', () => {
+    const grid = makeGrid([
+      '##',
+      '##',
+    ]);
+    expect(getSlotLengths(grid)).toEqual({ horiz: [], vert: [], all: [] });
+  });
+});

--- a/__tests__/wordBank.test.ts
+++ b/__tests__/wordBank.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { buildWordBank } from '../lib/wordBank';
+
+describe('buildWordBank', () => {
+  it('normalizes, filters, dedupes and sorts words', () => {
+    const words = ['apple', 'Banana', 'APPLE', 'pear', 'abc', 'z', 'AB', 'pine-apple'];
+    const bank = buildWordBank(words);
+    expect(bank).toEqual({
+      3: ['ABC'],
+      4: ['PEAR'],
+      5: ['APPLE'],
+      6: ['BANANA'],
+    });
+  });
+});

--- a/lib/coverage.ts
+++ b/lib/coverage.ts
@@ -1,0 +1,17 @@
+import type { WordBank } from './wordBank';
+
+export function validateCoverage(slotLengths: number[], bank: WordBank) {
+  const need: Record<number, number> = {};
+  for (const len of slotLengths) {
+    if (len === 2) continue;
+    need[len] = (need[len] || 0) + 1;
+  }
+
+  const missing: number[] = [];
+  for (const [lenStr, count] of Object.entries(need)) {
+    const len = Number(lenStr);
+    const available = bank[len]?.length ?? 0;
+    if (available < count) missing.push(len);
+  }
+  return { need, missing };
+}

--- a/lib/gridSlots.ts
+++ b/lib/gridSlots.ts
@@ -1,0 +1,36 @@
+import type { Cell } from './puzzle';
+
+export function getSlotLengths(grid: Cell[][]) {
+  const size = grid.length;
+  const horiz: number[] = [];
+  const vert: number[] = [];
+
+  for (let r = 0; r < size; r++) {
+    let len = 0;
+    for (let c = 0; c < size; c++) {
+      if (!grid[r][c].isBlack) {
+        len++;
+      }
+      if (grid[r][c].isBlack || c === size - 1) {
+        if (len > 1) horiz.push(len);
+        len = 0;
+      }
+    }
+  }
+
+  for (let c = 0; c < size; c++) {
+    let len = 0;
+    for (let r = 0; r < size; r++) {
+      if (!grid[r][c].isBlack) {
+        len++;
+      }
+      if (grid[r][c].isBlack || r === size - 1) {
+        if (len > 1) vert.push(len);
+        len = 0;
+      }
+    }
+  }
+
+  const all = [...horiz, ...vert].sort((a, b) => a - b);
+  return { horiz: horiz.sort((a, b) => a - b), vert: vert.sort((a, b) => a - b), all };
+}

--- a/lib/wordBank.ts
+++ b/lib/wordBank.ts
@@ -1,0 +1,20 @@
+export type WordBank = Record<number, string[]>;
+
+export function buildWordBank(words: string[]): WordBank {
+  const bank: Record<number, Set<string>> = {};
+
+  for (const raw of words) {
+    const word = raw.trim().toUpperCase();
+    if (!/^[A-Z]{3,15}$/.test(word)) continue;
+    const len = word.length;
+    if (!bank[len]) bank[len] = new Set();
+    bank[len].add(word);
+  }
+
+  const out: WordBank = {};
+  for (const lenStr in bank) {
+    const len = Number(lenStr);
+    out[len] = Array.from(bank[len]).sort();
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
- add word bank builder that normalizes, filters, dedupes, and sorts words
- compute slot lengths for puzzle grids and expose coverage validator
- cover new utilities with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a50568ccd8832c9b44a8d60603f6d5