### PR TITLE
Separate fallback handling from solver candidates

### DIFF
--- a/__tests__/solver.test.ts
+++ b/__tests__/solver.test.ts
@@ -81,6 +81,34 @@ describe("solver logging", () => {
     expect(parsed).toMatchObject({ message: "fallback_rate_exceeded" });
     warnSpy.mockRestore();
   });
+
+  it("logs fallback usage with slot and answer", () => {
+    const board = [["", "", ""]];
+    const slots: SolverSlot[] = [
+      { row: 0, col: 0, length: 3, direction: "across", id: "across_0_0" },
+    ];
+    const dict: WordEntry[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const res = solve({
+      board,
+      slots,
+      dict,
+      rng: () => 0,
+      opts: { maxFallbackRate: 1 },
+    });
+    expect(res.ok).toBe(true);
+    const call = logSpy.mock.calls.find((c) =>
+      c[0].includes("\"message\":\"fallback_word_used\"")
+    );
+    expect(call).toBeTruthy();
+    const parsed = JSON.parse(call![0]);
+    expect(parsed).toMatchObject({
+      message: "fallback_word_used",
+      slot: "across_0_0",
+      answer: "CAT",
+    });
+    logSpy.mockRestore();
+  });
 });
 
 describe("solver puzzle", () => {

--- a/src/data/fallbackWords.ts
+++ b/src/data/fallbackWords.ts
@@ -1,18 +1,7 @@
 const fallbackWords: Record<number, string[]> = {
-  2: ["GO"],
-  3: ["CAT"],
-  4: ["DOOR"],
-  5: ["APPLE"],
-  6: ["ORANGE"],
-  7: ["PICTURE"],
-  8: ["COMPUTER"],
-  9: ["NOTEBOOKS"],
- 10: ["STRAWBERRY"],
- 11: ["COUNTRYSIDE"],
- 12: ["RELATIONSHIP"],
- 13: ["UNDERSTANDING"],
- 14: ["RESPONSIBILITY"],
- 15: ["CONGRATULATIONS"],
+  3: ["CAT", "DOG", "SUN"],
+  13: ["UNDERSTANDING", "KNOWLEDGEABLE"],
+  15: ["CONGRATULATIONS", "ACKNOWLEDGMENTS"],
 };
 
 export default fallbackWords;


### PR DESCRIPTION
## Summary
- restrict `candidatesFor` to hero and dictionary entries only
- introduce fallback lookup when a slot has no candidates
- track curated fallback pools and log each fallback fill with its slot ID

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5f432e760832c952e2030dd4594e7