### PR TITLE
Enhance solver logging and restart summaries

### DIFF
--- a/__tests__/solver.test.ts
+++ b/__tests__/solver.test.ts
@@ -104,8 +104,8 @@ describe("solver logging", () => {
     const parsed = JSON.parse(call![0]);
     expect(parsed).toMatchObject({
       message: "fallback_word_used",
-      slot: "across_0_0",
-      answer: "CAT",
+      slotId: "across_0_0",
+      word: "CAT",
     });
     logSpy.mockRestore();
   });

--- a/lib/puzzle.ts
+++ b/lib/puzzle.ts
@@ -290,6 +290,12 @@ export function generateDaily(
           },
         });
         if (result.ok) break;
+        logInfo('restart_summary', {
+          maskAttempt: attempt + 1,
+          restart: restart + 1,
+          reason: result.reason,
+          fillAttempts: result.attempts,
+        });
         if (dict.length > 0) blacklist.add(dict[0].answer);
       }
 
@@ -301,6 +307,7 @@ export function generateDaily(
             (w.answer.length === 13 || w.answer.length === 15 || w.answer.length === 3) &&
             !blacklist.has(w.answer),
         );
+        let relaxedRestart = 0;
         while (!result || !result.ok) {
           const board = baseBoard.map((row) => [...row]);
           result = solve({
@@ -316,9 +323,16 @@ export function generateDaily(
             },
           });
           if (!result.ok) {
+            logInfo('restart_summary', {
+              maskAttempt: attempt + 1,
+              restart: `relaxed-${relaxedRestart + 1}`,
+              reason: result.reason,
+              fillAttempts: result.attempts,
+            });
             const dict = remaining.filter((w) => !blacklist.has(w.answer));
             if (dict.length === 0) break;
             blacklist.add(dict[0].answer);
+            relaxedRestart++;
           }
         }
       }

--- a/tests/lib/puzzle.test.ts
+++ b/tests/lib/puzzle.test.ts
@@ -27,10 +27,10 @@ describe('generateDaily', () => {
     const wordList = largeWordList().filter((w) => w.answer.length !== 3);
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     expect(() => {
-      generateDaily('seed', wordList, [], { maxFallbackRate: 1 });
+      generateDaily('seed', wordList, [], { maxFallbackRate: 1, maxFillAttempts: 10, maxMasks: 1 });
     }).toThrow();
     logSpy.mockRestore();
-  });
+  }, 20000);
 });
 
 describe('coordsToIndex', () => {


### PR DESCRIPTION
## Summary
- enrich solver backtracking logs with slot details, candidate counts, chosen words, and undo reasons
- log restart summaries for each failed fill attempt in `generateDaily`
- adjust tests for new log schema and performance

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6105de978832c9416d7c5d50f86e2