### PR TITLE
feat: build candidate pool from word sources

### DIFF
--- a/lib/candidatePool.ts
+++ b/lib/candidatePool.ts
@@ -1,0 +1,55 @@
+import fallbackWords from "../src/data/fallbackWords";
+import { isValidFill } from "@/utils/validateWord";
+
+/**
+ * Normalize an answer string by trimming, uppercasing and ensuring it is a
+ * single word containing only the letters A-Z. Returns null if the input
+ * contains whitespace, punctuation or otherwise fails validation.
+ */
+export function normalizeAnswer(input: string): string | null {
+  const word = input.trim().toUpperCase();
+  // Reject if not purely letters or contains multiple words
+  if (!/^[A-Z]+$/.test(word)) return null;
+  // Ensure the word passes fill validation (min length handled by caller)
+  if (!isValidFill(word, 3)) return null;
+  return word;
+}
+
+/**
+ * Build a candidate pool mapping word length to a list of unique answers.
+ * Primary sources are supplied as an array of string arrays. All entries are
+ * normalized and invalid or multi-word entries are discarded. Fallback lists
+ * are merged automatically.
+ */
+export function buildCandidatePool(
+  sources: string[][] = [],
+): Map<number, string[]> {
+  const byLen = new Map<number, Set<string>>();
+
+  const addWord = (raw: string) => {
+    const word = normalizeAnswer(raw);
+    if (!word) return;
+    const len = word.length;
+    if (!byLen.has(len)) byLen.set(len, new Set());
+    byLen.get(len)!.add(word);
+  };
+
+  // Add words from primary sources
+  for (const list of sources) {
+    for (const w of list) addWord(w);
+  }
+
+  // Merge fallback lists
+  for (const words of Object.values(fallbackWords)) {
+    for (const w of words) addWord(w);
+  }
+
+  // Convert sets to arrays
+  const out = new Map<number, string[]>();
+  for (const [len, set] of byLen.entries()) {
+    out.set(len, Array.from(set));
+  }
+  return out;
+}
+
+export type CandidatePool = Map<number, string[]>;

--- a/tests/lib/candidatePool.test.ts
+++ b/tests/lib/candidatePool.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeAnswer, buildCandidatePool } from '../../lib/candidatePool';
+
+describe('normalizeAnswer', () => {
+  it('uppercases and trims valid single words', () => {
+    expect(normalizeAnswer('  hello ')).toBe('HELLO');
+  });
+
+  it('rejects multi-word or punctuated entries', () => {
+    expect(normalizeAnswer('New York')).toBeNull();
+    expect(normalizeAnswer('spider-man')).toBeNull();
+    expect(normalizeAnswer('hi!')).toBeNull();
+  });
+});
+
+describe('buildCandidatePool', () => {
+  it('normalizes, dedupes and merges fallback lists', () => {
+    const primary = [
+      ['cat', 'dog', 'multi word', 'bee'],
+      ['DOG', 'fox']
+    ];
+    const pool = buildCandidatePool(primary);
+    const len3 = pool.get(3) || [];
+    // Primary words normalized and deduped
+    expect(len3).toContain('CAT');
+    expect(len3).toContain('DOG');
+    expect(len3.filter((w) => w === 'DOG').length).toBe(1);
+    expect(len3).toContain('BEE');
+    expect(len3).toContain('FOX');
+    // Fallback words merged (SUN is from fallback list)
+    expect(len3).toContain('SUN');
+    // Fallback pool provides longer lengths as well
+    expect(pool.get(15)).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add `normalizeAnswer` helper to clean and validate answers
- add `buildCandidatePool` to aggregate word sources and fallback lists into a length-based map
- test candidate pool normalization, dedupe, and fallback merging

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a619600518832c8eaf2ef7b13601f1