### PR TITLE
Add candidate pool debug script

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,21 @@ pnpm gen:daily [hero terms...]
   ```
 
 - Lint the codebase with:
-  
+
   ```bash
   pnpm lint
   ```
 
 - WebAuthn authentication only accepts platform biometrics (e.g., Face ID).
   External security keys are not supported.
+
+## Local verification
+
+Inspect candidate pool sizes:
+
+```bash
+npm run tsx scripts/debugPool.ts
+```
 
 ## Dev gotcha
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "vitest run",
     "lint": "eslint .",
     "gen:daily": "tsx scripts/genDaily.ts",
+    "tsx": "tsx",
     "db:migrate": "prisma migrate deploy",
     "db:seed": "prisma db seed"
   },

--- a/scripts/debugPool.ts
+++ b/scripts/debugPool.ts
@@ -1,0 +1,39 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { buildCandidatePool } from '../lib/candidatePool';
+import fallbackWords from '../src/data/fallbackWords';
+
+async function main() {
+  // Load primary word lists if present
+  const allowlistPath = path.join(__dirname, '..', 'data', 'allowlist.json');
+  let allowlist: string[] = [];
+  try {
+    const raw = await fs.readFile(allowlistPath, 'utf8');
+    allowlist = JSON.parse(raw);
+  } catch {
+    // ignore if file missing
+  }
+
+  // Build pool from primary sources
+  const pool = buildCandidatePool([allowlist]);
+
+  // Ensure fallback words are merged
+  for (const [lenStr, words] of Object.entries(fallbackWords)) {
+    const len = Number(lenStr);
+    const existing = pool.get(len) || [];
+    const merged = new Set([...existing, ...words.map((w) => w.toUpperCase())]);
+    pool.set(len, Array.from(merged));
+  }
+
+  // Output counts per word length
+  const counts: Record<string, number> = {};
+  for (const [len, words] of pool.entries()) {
+    counts[len] = words.length;
+  }
+  console.table(counts);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add debug script to build candidate pool and report counts per word length
- expose `tsx` helper script and document local verification step

## Testing
- `npm run tsx scripts/debugPool.ts`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a61fa47b00832ca8a1e72e1b199487