### PR TITLE
Refactor fallbackWords into flat array

### DIFF
--- a/lib/candidatePool.ts
+++ b/lib/candidatePool.ts
@@ -39,10 +39,8 @@ export function buildCandidatePool(
     for (const w of list) addWord(w);
   }
 
-  // Merge fallback lists
-  for (const words of Object.values(fallbackWords)) {
-    for (const w of words) addWord(w);
-  }
+  // Merge fallback list
+  for (const w of fallbackWords) addWord(w);
 
   // Convert sets to arrays
   const out = new Map<number, string[]>();

--- a/lib/puzzle.ts
+++ b/lib/puzzle.ts
@@ -201,8 +201,9 @@ export function generateDaily(
       });
       verifyFallbackPools(requiredLens, heroesByLen, dictByLen);
       const fallbackByLen: Record<number, number> = {};
-      Object.entries(fallbackWords).forEach(([lenStr, words]) => {
-        fallbackByLen[Number(lenStr)] = (words as string[]).length;
+      fallbackWords.forEach((w) => {
+        const len = w.length;
+        fallbackByLen[len] = (fallbackByLen[len] || 0) + 1;
       });
       assertCoverage(requiredLens, { heroesByLen, dictByLen, fallbackByLen });
 

--- a/scripts/debugPool.ts
+++ b/scripts/debugPool.ts
@@ -18,10 +18,10 @@ async function main() {
   const pool = buildCandidatePool([allowlist]);
 
   // Ensure fallback words are merged
-  for (const [lenStr, words] of Object.entries(fallbackWords)) {
-    const len = Number(lenStr);
+  for (const w of fallbackWords) {
+    const len = w.length;
     const existing = pool.get(len) || [];
-    const merged = new Set([...existing, ...words.map((w) => w.toUpperCase())]);
+    const merged = new Set([...existing, w.toUpperCase()]);
     pool.set(len, Array.from(merged));
   }
 

--- a/scripts/genDaily.ts
+++ b/scripts/genDaily.ts
@@ -100,13 +100,11 @@ async function main() {
 
   let pool = buildCandidatePool(wordList);
   const fallbackEntries: WordEntry[] = [];
-  for (const words of Object.values(fallbackWords)) {
-    for (const w of words) {
-      const answer = w.trim().toUpperCase();
-      if (!/^[A-Z]+$/.test(answer)) continue;
-      if (!isValidFill(answer, 3)) continue;
-      fallbackEntries.push({ answer, clue: '' });
-    }
+  for (const w of fallbackWords) {
+    const answer = w.trim().toUpperCase();
+    if (!/^[A-Z]+$/.test(answer)) continue;
+    if (!isValidFill(answer, 3)) continue;
+    fallbackEntries.push({ answer, clue: '' });
   }
   const fallbackPool = buildCandidatePool(fallbackEntries);
   for (const [lenStr, entries] of Object.entries(fallbackPool)) {
@@ -120,7 +118,9 @@ async function main() {
     const have = pool[len]?.length || 0;
     if (have < minCount) {
       if (len === 13 || len === 15) {
-        const anchors = (fallbackWords[len] || []).map((w) => w.toUpperCase());
+        const anchors = fallbackWords
+          .filter((w) => w.length === len)
+          .map((w) => w.toUpperCase());
         for (const a of anchors) {
           if (!/^[A-Z]+$/.test(a)) continue;
           if (!pool[len]) pool[len] = [];
@@ -147,8 +147,12 @@ async function main() {
   }
 
   const baseHeroTerms = heroTerms.length > 0 ? heroTerms : defaultHeroTerms;
-  const long13 = (fallbackWords[13] || []).map((w) => w.toUpperCase());
-  const long15 = (fallbackWords[15] || []).map((w) => w.toUpperCase());
+  const long13 = fallbackWords
+    .filter((w) => w.length === 13)
+    .map((w) => w.toUpperCase());
+  const long15 = fallbackWords
+    .filter((w) => w.length === 15)
+    .map((w) => w.toUpperCase());
   const MAX_ATTEMPTS = 8;
   let puzzle: ReturnType<typeof generateDaily> | null = null;
   for (let attempt = 0; attempt < MAX_ATTEMPTS && !puzzle; attempt++) {

--- a/src/data/fallbackWords.ts
+++ b/src/data/fallbackWords.ts
@@ -9,38 +9,32 @@
  * Lists are intentionally small; puzzle generation will fail if too many
  * slots of a given length rely on fallbacks.
  */
-const fallbackWords: Record<number, string[]> = {
+const fallbackWords = [
   // Short, common nouns for 3‑letter slots.
-  3: [
-    "CAT",
-    "DOG",
-    "SUN",
-    "BEE",
-    "FOX",
-    "HAT",
-    "INK",
-    "JAM",
-    "KEY",
-    "OWL",
-  ],
+  "CAT",
+  "DOG",
+  "SUN",
+  "BEE",
+  "FOX",
+  "HAT",
+  "INK",
+  "JAM",
+  "KEY",
+  "OWL",
 
   // Assorted neutral 13‑letter words.
-  13: [
-    "UNDERSTANDING",
-    "KNOWLEDGEABLE",
-    "DETERMINATION",
-    "APPRECIATIONS",
-    "COMMUNICATION",
-  ],
+  "UNDERSTANDING",
+  "KNOWLEDGEABLE",
+  "DETERMINATION",
+  "APPRECIATIONS",
+  "COMMUNICATION",
 
   // Assorted neutral 15‑letter words.
-  15: [
-    "CONGRATULATIONS",
-    "ACKNOWLEDGMENTS",
-    "UNDERSTATEMENTS",
-    "MICROSCOPICALLY",
-    "RECOMMENDATIONS",
-  ],
-};
+  "CONGRATULATIONS",
+  "ACKNOWLEDGMENTS",
+  "UNDERSTATEMENTS",
+  "MICROSCOPICALLY",
+  "RECOMMENDATIONS",
+];
 
 export default fallbackWords;

--- a/src/utils/getFallback.ts
+++ b/src/utils/getFallback.ts
@@ -1,11 +1,15 @@
-import rawFallbackWords from "../data/fallbackWords";
+import fallbackWords from "../data/fallbackWords";
 import { isValidFill } from "./validateWord";
 
-const FALLBACK_WORDS: Record<number, string[]> = Object.fromEntries(
-  Object.entries(rawFallbackWords).map(([len, words]) => [
-    Number(len),
-    words.filter((w) => w.length === Number(len) && isValidFill(w, 2)),
-  ]),
+const FALLBACK_WORDS: Record<number, string[]> = fallbackWords.reduce(
+  (acc, w) => {
+    if (!isValidFill(w, 2)) return acc;
+    const len = w.length;
+    if (!acc[len]) acc[len] = [];
+    acc[len].push(w);
+    return acc;
+  },
+  {} as Record<number, string[]>,
 );
 
 export function getFallback(


### PR DESCRIPTION
## Summary
- replace fallbackWords record with a flat list of strings
- update fallback word enrichment and consumers to derive lengths from the array

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6271ca858832cb8a127cf0ecf48dc