### PR TITLE
Remove fallback word support

### DIFF
--- a/lib/puzzle.ts
+++ b/lib/puzzle.ts
@@ -4,7 +4,6 @@ import { planHeroPlacements } from './heroPlacement';
 import { buildMask } from '@/grid/mask';
 import * as validatePuzzle from '../src/validate/puzzle';
 import { assertCoverage } from '../src/validate/coverage';
-import { candidatePoolByLength } from './candidatePool';
 import { repairMask } from './repairMask';
 import { solve, SolverSlot } from './solver';
 import { logInfo, logError } from '@/utils/logger';
@@ -172,11 +171,7 @@ export function generateDaily(
         const len = w.answer.length;
         dictByLen[len] = (dictByLen[len] || 0) + 1;
       });
-      const fallbackByLen: Record<number, number> = {};
-      for (const [len, words] of candidatePoolByLength.entries()) {
-        fallbackByLen[len] = words.length;
-      }
-      assertCoverage(requiredLens, { heroesByLen, dictByLen, fallbackByLen });
+      assertCoverage(requiredLens, { heroesByLen, dictByLen });
 
       // build grid for slot finding
       const grid: string[] = [];

--- a/scripts/debugPool.ts
+++ b/scripts/debugPool.ts
@@ -1,31 +1,9 @@
-import { promises as fs } from 'fs';
-import path from 'path';
-import { buildCandidatePool, candidatePoolByLength } from '../lib/candidatePool';
+import { candidatePoolByLength } from '../lib/candidatePool';
 
 async function main() {
-  // Load primary word lists if present
-  const allowlistPath = path.join(__dirname, '..', 'data', 'allowlist.json');
-  let allowlist: string[] = [];
-  try {
-    const raw = await fs.readFile(allowlistPath, 'utf8');
-    allowlist = JSON.parse(raw);
-  } catch {
-    // ignore if file missing
-  }
-
-  // Build pool from primary sources
-  const pool = buildCandidatePool([allowlist]);
-
-  // Merge bank words
-  for (const [len, words] of candidatePoolByLength.entries()) {
-    const existing = pool.get(len) || [];
-    const merged = new Set([...existing, ...words]);
-    pool.set(len, Array.from(merged));
-  }
-
-  // Output counts per word length
+  // Output counts per word length from bank-derived pool
   const counts: Record<string, number> = {};
-  for (const [len, words] of pool.entries()) {
+  for (const [len, words] of candidatePoolByLength.entries()) {
     counts[len] = words.length;
   }
   console.table(counts);

--- a/src/validate/coverage.ts
+++ b/src/validate/coverage.ts
@@ -1,7 +1,6 @@
 export type PoolsByLength = {
   heroesByLen: Record<number, number>;
   dictByLen: Record<number, number>;
-  fallbackByLen: Record<number, number>;
 };
 
 export function assertCoverage(requiredLens: number[], pools: PoolsByLength): void {
@@ -14,17 +13,15 @@ export function assertCoverage(requiredLens: number[], pools: PoolsByLength): vo
     const len = Number(lenStr);
     const heroes = pools.heroesByLen[len] || 0;
     const dict = pools.dictByLen[len] || 0;
-    const fallback = pools.fallbackByLen[len] || 0;
     const available = heroes + dict;
     if (available >= needed) continue;
-    if (fallback > 0) continue;
     throw {
       message: 'puzzle_invalid',
       error: 'slot_coverage',
       detail: {
         length: len,
         required: needed,
-        available: { heroes, dict, fallback },
+        available: { heroes, dict },
       },
     };
   }

--- a/tests/lib/puzzle.test.ts
+++ b/tests/lib/puzzle.test.ts
@@ -14,14 +14,12 @@ describe('generateDaily', () => {
     expect(puzzle.across[0].enumeration).toBe('(7)');
   });
 
-  it('uses fallback when no matching word is found', () => {
-    const wordList = largeWordList().filter((w) => w.answer.length !== 3);
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    expect(() => {
-      generateDaily('seed', wordList, [], { maxFillAttempts: 10, maxMasks: 1 });
-    }).toThrow();
-    logSpy.mockRestore();
-  }, 20000);
+    it('errors when no matching word is found', () => {
+      const wordList = largeWordList().filter((w) => w.answer.length !== 3);
+      expect(() => {
+        generateDaily('seed', wordList, [], { maxFillAttempts: 10, maxMasks: 1 });
+      }).toThrow();
+    }, 20000);
 });
 
 describe('coordsToIndex', () => {


### PR DESCRIPTION
## Summary
- drop fallback pool from coverage checks and puzzle generation
- simplify debugPool script to report bank-sourced candidate counts
- adjust tests for removed fallback logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a63a23d418832cb3c48b9ed7d8fdd7