### PR TITLE
feat: add bank coverage check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ You can load it in your shell with `source .env` or by copying it to `.env.local
 ## Puzzle quality gate
 
 Daily puzzles are produced with a deterministic generation pipeline.
+Run a quick bank coverage check before generating:
+
+```bash
+npm run tsx scripts/checkBanks.ts
+```
+
+This prints counts of unique normalized entries by answer length.
 Run the generator to build the puzzle for today. You can optionally supply
 "hero" terms to pin in the grid:
 

--- a/scripts/checkBanks.ts
+++ b/scripts/checkBanks.ts
@@ -1,0 +1,27 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { normalizeAnswer } from '../lib/candidatePool';
+
+async function main() {
+  const bankDir = path.join(process.cwd(), 'banks');
+  const files = (await fs.readdir(bankDir)).filter((f) => f.endsWith('.txt'));
+  const words = new Set<string>();
+  for (const file of files) {
+    const data = await fs.readFile(path.join(bankDir, file), 'utf8');
+    for (const line of data.split(/\r?\n/)) {
+      const word = normalizeAnswer(line);
+      if (word) words.add(word);
+    }
+  }
+  const counts: Record<number, number> = {};
+  for (const w of words) {
+    const len = w.length;
+    counts[len] = (counts[len] || 0) + 1;
+  }
+  console.table(counts);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `scripts/checkBanks.ts` to inspect bank coverage by answer length
- document running the bank check before generating a puzzle

## Testing
- `npm run tsx scripts/checkBanks.ts`
- `npm test` *(fails: network requests blocked)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a645a0ef88832c8598764fc27f4054