### PR TITLE
Prioritize longer solver slots before MRV heuristics

### DIFF
--- a/lib/solver.ts
+++ b/lib/solver.ts
@@ -184,6 +184,7 @@ export function solve(params: SolveParams): SolveResult {
   const orderSlots = (all: SolverSlot[]): SolverSlot[] => {
     const sortHeuristics = (arr: SolverSlot[]) =>
       arr.sort((a, b) => {
+        if (b.length !== a.length) return b.length - a.length;
         const ca = candidateCount(a);
         const cb = candidateCount(b);
         if (ca !== cb) return ca - cb;

--- a/tests/lib/solver.test.ts
+++ b/tests/lib/solver.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { solve, SolverSlot } from '../../lib/solver';
+import type { WordEntry } from '../../lib/puzzle';
+import * as logger from '@/utils/logger';
+
+describe('orderSlots', () => {
+  it('prefers longer slots when candidate counts are equal', () => {
+    const board = [
+      ['', '', '', '', ''],
+      ['', '', '', '', ''],
+    ];
+    const slots: SolverSlot[] = [
+      { id: 'short', row: 1, col: 0, length: 3, direction: 'across' },
+      { id: 'long', row: 0, col: 0, length: 5, direction: 'across' },
+    ];
+    const dict: WordEntry[] = [
+      { answer: 'FGH', clue: '' },
+      { answer: 'ABCDE', clue: '' },
+    ];
+    const infoSpy = vi.spyOn(logger, 'logInfo').mockImplementation(() => {});
+    const result = solve({ board, slots, dict, rng: () => 0 });
+    const placeCalls = infoSpy.mock.calls.filter(([msg]) => msg === 'place');
+    infoSpy.mockRestore();
+    expect(result.ok).toBe(true);
+    expect(placeCalls[0][1]).toMatchObject({ slotId: 'long' });
+  });
+});


### PR DESCRIPTION
## Summary
- prioritize longer slots before MRV and degree heuristics in solver ordering
- add unit test verifying longer slots chosen first when candidate counts tie

## Testing
- `npm test`
- `npm test tests/lib/solver.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a64fbdff3c832caad64b47a5f0ecfb