### PR TITLE
feat: add configurable search caps

### DIFF
--- a/lib/puzzle.ts
+++ b/lib/puzzle.ts
@@ -43,7 +43,9 @@ export function generateDaily(
   heroTerms: string[] = [],
   opts: {
     heroThreshold?: number;
-    maxFillAttempts?: number;
+    maxBranchAttempts?: number;
+    maxTotalAttempts?: number;
+    maxTimeBudgetMs?: number;
     maxMasks?: number;
   } = {},
   mask?: boolean[][],
@@ -253,7 +255,9 @@ export function generateDaily(
           rng: localRng,
           opts: {
             heroThreshold: opts.heroThreshold,
-            maxFillAttempts: opts.maxFillAttempts,
+            maxBranchAttempts: opts.maxBranchAttempts,
+            maxTotalAttempts: opts.maxTotalAttempts,
+            maxTimeBudgetMs: opts.maxTimeBudgetMs,
           },
         });
         if (result.ok) break;
@@ -285,7 +289,9 @@ export function generateDaily(
             rng: localRng,
             opts: {
               heroThreshold: opts.heroThreshold,
-              maxFillAttempts: opts.maxFillAttempts,
+              maxBranchAttempts: opts.maxBranchAttempts,
+              maxTotalAttempts: opts.maxTotalAttempts,
+              maxTimeBudgetMs: opts.maxTimeBudgetMs,
             },
           });
           if (!result.ok) {

--- a/tests/lib/puzzle.test.ts
+++ b/tests/lib/puzzle.test.ts
@@ -17,7 +17,7 @@ describe('generateDaily', () => {
     it('errors when no matching word is found', () => {
       const wordList = largeWordList().filter((w) => w.answer.length !== 3);
       expect(() => {
-        generateDaily('seed', wordList, [], { maxFillAttempts: 10, maxMasks: 1 });
+        generateDaily('seed', wordList, [], { maxBranchAttempts: 10, maxMasks: 1 });
       }).toThrow();
     }, 20000);
 });


### PR DESCRIPTION
## Summary
- add env/CLI caps for branch attempts, total attempts, and time budget in daily generator
- propagate caps through generateDaily into solver
- abort solver on cap hit with dead_end logging and final_failure once exhausted

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a73d62bddc832ca8d7f400a9bc7b1b