### PR TITLE
refactor: centralize answer normalization

### DIFF
--- a/__tests__/solver_backtrack.test.ts
+++ b/__tests__/solver_backtrack.test.ts
@@ -3,6 +3,7 @@ import seedrandom from 'seedrandom';
 import { findSlots } from '../lib/slotFinder';
 import { solveWithBacktracking, type SolverSlot } from '../lib/solver';
 import { largeWordList } from '../tests/helpers/wordList';
+import { answerLen } from '../lib/candidatePool';
 
 describe('solveWithBacktracking', () => {
   const size = 15;
@@ -17,7 +18,7 @@ describe('solveWithBacktracking', () => {
     direction: 'across',
     id: `a_${s.row}_${s.col}`,
   }));
-  const dict = largeWordList().filter((w) => w.answer.length === 15).slice(0, 1);
+  const dict = largeWordList().filter((w) => answerLen(w.answer) === 15).slice(0, 1);
   const seeds = ['alpha', 'beta', 'gamma'];
 
   for (const seed of seeds) {

--- a/__tests__/wordBank.test.ts
+++ b/__tests__/wordBank.test.ts
@@ -23,6 +23,8 @@ describe('buildWordBank', () => {
       4: ['KIWI', 'PEAR'],
       5: ['APPLE', 'GRAPE'],
       6: ['BANANA'],
+      9: ['PINEAPPLE'],
+      10: ['STRAWBERRY'],
     });
     expect(bank[2]).toBeUndefined();
   });

--- a/lib/puzzle.ts
+++ b/lib/puzzle.ts
@@ -8,6 +8,7 @@ import { repairMask } from './repairMask';
 import { solve, SolverSlot } from './solver';
 import { logInfo, logError } from '@/utils/logger';
 import seedrandom from 'seedrandom';
+import { answerLen } from './candidatePool';
 
 const MAX_RESTARTS = 5;
 
@@ -175,12 +176,12 @@ export function generateDaily(
       ];
       const heroesByLen: Record<number, number> = {};
       heroTerms.forEach((t) => {
-        const len = t.length;
+        const len = answerLen(t);
         heroesByLen[len] = (heroesByLen[len] || 0) + 1;
       });
       const dictByLen: Record<number, number> = {};
       wordList.forEach((w) => {
-        const len = w.answer.length;
+        const len = answerLen(w.answer);
         dictByLen[len] = (dictByLen[len] || 0) + 1;
       });
       assertCoverage(requiredLens, { heroesByLen, dictByLen });
@@ -288,7 +289,7 @@ export function generateDaily(
         const localRng = seedrandom(localSeed);
         const curatedAnchors = remaining.filter(
           (w) =>
-            (w.answer.length === 13 || w.answer.length === 15 || w.answer.length === 3) &&
+            (answerLen(w.answer) === 13 || answerLen(w.answer) === 15 || answerLen(w.answer) === 3) &&
             !blacklist.has(w.answer),
         );
         let relaxedRestart = 0;

--- a/lib/solver.ts
+++ b/lib/solver.ts
@@ -2,6 +2,7 @@ import { isValidFill } from "@/utils/validateWord";
 import { logInfo, logWarn } from "@/utils/logger";
 import type { WordEntry } from "./puzzle";
 import type { Slot } from "./slotFinder";
+import { answerLen } from "./candidatePool";
 import seedrandom from "seedrandom";
 
 export type SolverSlot = Slot & { direction: "across" | "down"; id: string };
@@ -183,7 +184,7 @@ export function solve(params: SolveParams): SolveResult {
   const candidatesFor = (pattern: string[], len: number): WordEntry[] => {
     if (BANNED_LENGTHS.has(len)) return [];
     const matches = (w: WordEntry) =>
-      w.answer.length === len &&
+      answerLen(w.answer) === len &&
       pattern.every((ch, i) => !ch || w.answer[i] === ch) &&
       isValidFill(w.answer, minLen);
     const heroCandidates = heroes.filter(matches).sort(

--- a/lib/validatePuzzle.ts
+++ b/lib/validatePuzzle.ts
@@ -3,6 +3,7 @@ import { findSlots, Slot } from './slotFinder';
 import { cleanClue } from './clueClean';
 import { isValidFill } from '@/utils/validateWord';
 import { symCell } from '@/grid/symmetry';
+import { answerLen } from './candidatePool';
 
 export function validatePuzzle(
   puzzle: Puzzle,
@@ -61,8 +62,9 @@ export function validatePuzzle(
       if (clue.length !== slot.length) {
         errors.push(`${dir} clue ${clue.number} length ${clue.length} ≠ slot length ${slot.length}`);
       }
-      if (answer.length !== slot.length) {
-        errors.push(`${dir} answer ${clue.number} length ${answer.length} ≠ slot length ${slot.length}`);
+      const ansLen = answerLen(answer);
+      if (ansLen !== slot.length) {
+        errors.push(`${dir} answer ${clue.number} length ${ansLen} ≠ slot length ${slot.length}`);
       }
       if (!isValidFill(answer, 3)) {
         errors.push(`${dir} answer ${clue.number} not allowed: ${answer}`);

--- a/lib/wordBank.ts
+++ b/lib/wordBank.ts
@@ -1,12 +1,14 @@
+import { normalizeAnswer, answerLen } from "./candidatePool";
+
 export type WordBank = Record<number, string[]>;
 
 export function buildWordBank(words: string[]): WordBank {
   const bank: Record<number, Set<string>> = {};
 
   for (const raw of words) {
-    const word = raw.trim().toUpperCase();
-    if (!/^[A-Z]{3,15}$/.test(word)) continue;
-    const len = word.length;
+    const word = normalizeAnswer(raw);
+    const len = answerLen(raw);
+    if (len < 3 || len > 15) continue;
     if (!bank[len]) bank[len] = new Set();
     bank[len].add(word);
   }

--- a/scripts/checkBanks.ts
+++ b/scripts/checkBanks.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import path from 'path';
-import { normalizeAnswer } from '../lib/candidatePool';
+import { normalizeAnswer, answerLen } from '../lib/candidatePool';
 
 async function main() {
   const bankDir = path.join(process.cwd(), 'banks');
@@ -10,12 +10,12 @@ async function main() {
     const data = await fs.readFile(path.join(bankDir, file), 'utf8');
     for (const line of data.split(/\r?\n/)) {
       const word = normalizeAnswer(line);
-      if (word) words.add(word);
+      if (answerLen(line) > 0) words.add(word);
     }
   }
   const counts: Record<number, number> = {};
   for (const w of words) {
-    const len = w.length;
+    const len = answerLen(w);
     counts[len] = (counts[len] || 0) + 1;
   }
   console.table(counts);

--- a/src/utils/chooseAnswer.ts
+++ b/src/utils/chooseAnswer.ts
@@ -1,5 +1,6 @@
 import { isValidFill } from "./validateWord";
 import type { WordEntry } from "../../lib/puzzle";
+import { answerLen } from "../../lib/candidatePool";
 
 export function chooseAnswer(
   len: number,
@@ -12,7 +13,7 @@ export function chooseAnswer(
   const minLen = 3;
   const idx = pool.findIndex(
     (w) =>
-      w.answer.length === len &&
+      answerLen(w.answer) === len &&
       letters.every((ch, i) => !ch || w.answer[i] === ch) &&
       isValidFill(w.answer, minLen),
   );

--- a/src/validate/puzzle.ts
+++ b/src/validate/puzzle.ts
@@ -1,3 +1,5 @@
+import { answerLen } from "../../lib/candidatePool";
+
 export function validateSymmetry(grid: boolean[][]): boolean {
   const size = grid.length;
   for (let r = 0; r < size; r++) {
@@ -123,6 +125,6 @@ export function validateMinSlotLength(
 export function validateComplete(
   cells: { isBlack: boolean; answer: string }[],
 ): boolean {
-  return cells.every((cell) => cell.isBlack || (cell.answer?.trim().length ?? 0) > 0);
+  return cells.every((cell) => cell.isBlack || answerLen(cell.answer ?? "") > 0);
 }
 

--- a/tests/lib/candidatePool.test.ts
+++ b/tests/lib/candidatePool.test.ts
@@ -3,20 +3,21 @@ import fs from 'fs';
 import path from 'path';
 import {
   normalizeAnswer,
+  answerLen,
   buildCandidatePool,
   candidatePoolByLength,
   banlist,
 } from '../../lib/candidatePool';
 
 describe('normalizeAnswer', () => {
-  it('uppercases and trims valid single words', () => {
-    expect(normalizeAnswer('  hello ')).toBe('HELLO');
+  it('removes non letters and uppercases', () => {
+    expect(normalizeAnswer('  spider-man ')).toBe('SPIDERMAN');
   });
+});
 
-  it('rejects multi-word or punctuated entries', () => {
-    expect(normalizeAnswer('New York')).toBeNull();
-    expect(normalizeAnswer('spider-man')).toBeNull();
-    expect(normalizeAnswer('hi!')).toBeNull();
+describe('answerLen', () => {
+  it('computes length after normalization', () => {
+    expect(answerLen(' hi! ')).toBe(2);
   });
 });
 
@@ -35,7 +36,6 @@ describe('buildCandidatePool', () => {
     expect(len3.filter((w) => w.answer === 'DOG').length).toBe(1);
     expect(answers).toContain('BEE');
     expect(answers).not.toContain('FOX');
-    expect(answers).not.toContain('MULTI WORD');
     const cat = len3.find((w) => w.answer === 'CAT')!;
     const dog = len3.find((w) => w.answer === 'DOG')!;
     expect(cat.frequency).toBeLessThan(dog.frequency);
@@ -57,9 +57,9 @@ describe('candidatePoolByLength', () => {
     for (const f of files) {
       const lines = fs.readFileSync(path.join(bankDir, f), 'utf8').split(/\r?\n/);
       for (const line of lines) {
+        if (answerLen(line) === 0) continue;
         const word = normalizeAnswer(line);
-        if (!word) continue;
-        const len = word.length;
+        const len = answerLen(line);
         if (!expected.has(len)) expected.set(len, new Set());
         expected.get(len)!.add(word);
       }

--- a/tests/lib/puzzle.test.ts
+++ b/tests/lib/puzzle.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { generateDaily, coordsToIndex, loadDemoFromFile, WordEntry } from '../../lib/puzzle';
 import { largeWordList } from '../helpers/wordList';
+import { answerLen } from '../../lib/candidatePool';
 
 describe('generateDaily', () => {
   it('rejects answers whose length does not match a slot', () => {
@@ -15,7 +16,7 @@ describe('generateDaily', () => {
   });
 
     it('errors when no matching word is found', () => {
-      const wordList = largeWordList().filter((w) => w.answer.length !== 3);
+      const wordList = largeWordList().filter((w) => answerLen(w.answer) !== 3);
       expect(() => {
         generateDaily('seed', wordList, [], { maxBranchAttempts: 10, maxMasks: 1 });
       }).toThrow();


### PR DESCRIPTION
## Summary
- Simplify answer sanitation by introducing `normalizeAnswer` and helper `answerLen`
- Refactor candidate pool, solver, and word bank to use new normalization helpers
- Update scripts, validators, and tests to respect normalized word lengths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a76304929c832c9b3a74d795c5a463