### PR TITLE
Normalize candidate length checks

### DIFF
--- a/scripts/genDaily.ts
+++ b/scripts/genDaily.ts
@@ -378,13 +378,23 @@ async function main() {
         clues.forEach((_, idx) => {
           const slot = slotArr[idx];
           if (!slot) return;
-          let ans = '';
+          let raw = '';
           for (let k = 0; k < slot.length; k++) {
             const cellIdx =
               dir === 'across'
                 ? slot.row * size + slot.col + k
                 : (slot.row + k) * size + slot.col;
-            ans += puzzle!.cells[cellIdx].answer;
+            raw += puzzle!.cells[cellIdx].answer;
+          }
+          const ans = normalizeAnswer(raw);
+          if (ans.length !== slot.length) {
+            logError('puzzle_invalid', {
+              attempt,
+              error: `${dir} clue length mismatch`,
+              clueIndex: idx,
+              want: slot.length,
+              got: ans.length,
+            });
           }
           const valid = isValidFill(ans, 3);
           if (!valid) {

--- a/src/utils/chooseAnswer.ts
+++ b/src/utils/chooseAnswer.ts
@@ -1,6 +1,6 @@
 import { isValidFill } from "./validateWord";
 import type { WordEntry } from "../../lib/puzzle";
-import { answerLen } from "../../lib/candidatePool";
+import { answerLen, normalizeAnswer } from "../../lib/candidatePool";
 
 export function chooseAnswer(
   len: number,
@@ -11,12 +11,14 @@ export function chooseAnswer(
     throw new Error("Two-letter answers are banned (slotLen=2).");
   }
   const minLen = 3;
-  const idx = pool.findIndex(
-    (w) =>
+  const idx = pool.findIndex((w) => {
+    const ans = normalizeAnswer(w.answer);
+    return (
       answerLen(w.answer) === len &&
-      letters.every((ch, i) => !ch || w.answer[i] === ch) &&
-      isValidFill(w.answer, minLen),
-  );
+      letters.every((ch, i) => !ch || ans[i] === ch) &&
+      isValidFill(ans, minLen)
+    );
+  });
   if (idx !== -1) {
     return pool.splice(idx, 1)[0];
   }


### PR DESCRIPTION
## Summary
- normalize candidate answers before slot filtering
- detect answer/slot length mismatches when placing words
- validate generated puzzle answers against slot lengths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a783e62d94832c8c120d37903873f0