### PR TITLE
feat: parse LLM-generated word lists

### DIFF
--- a/lib/parseGen.ts
+++ b/lib/parseGen.ts
@@ -1,0 +1,45 @@
+import { normalizeAnswer } from './candidatePool';
+
+export type GenItem = { answer: string; clue: string; source?: string };
+
+function stripMarkdown(input: string): string {
+  let out = input;
+  // Remove fenced code blocks
+  out = out.replace(/```[\s\S]*?```/g, '');
+  // Remove inline code
+  out = out.replace(/`([^`]*)`/g, '$1');
+  // Remove bold/italic markers
+  out = out.replace(/\*\*([^*]+)\*\*/g, '$1');
+  out = out.replace(/\*([^*]+)\*/g, '$1');
+  out = out.replace(/__([^_]+)__/g, '$1');
+  out = out.replace(/_([^_]+)_/g, '$1');
+  return out.trim();
+}
+
+export function parseGen(output: unknown): GenItem[] {
+  let data: unknown;
+  try {
+    if (typeof output === 'string') {
+      data = JSON.parse(output);
+    } else {
+      data = JSON.parse(String(output));
+    }
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(data)) return [];
+  const out: GenItem[] = [];
+  for (const item of data) {
+    if (!item || typeof item !== 'object') continue;
+    const ans = (item as any).answer;
+    const clueRaw = (item as any).clue;
+    if (typeof ans !== 'string' || typeof clueRaw !== 'string') continue;
+    const answer = normalizeAnswer(ans);
+    if (!answer) continue;
+    const clue = stripMarkdown(clueRaw);
+    const source = typeof (item as any).source === 'string' ? (item as any).source : undefined;
+    out.push({ answer, clue, source });
+  }
+  return out;
+}
+

--- a/scripts/genDaily.ts
+++ b/scripts/genDaily.ts
@@ -13,6 +13,7 @@ import { isValidFill } from '../utils/validateWord';
 import { getSlotLengths } from '../lib/gridSlots';
 import { buildWordBank } from '../lib/wordBank';
 import { validateCoverage } from '../lib/coverage';
+import { parseGen } from '../lib/parseGen';
 import {
   buildCandidatePool as buildBankPool,
   normalizeAnswer,
@@ -202,7 +203,12 @@ async function main() {
   let baseWordList: WordEntry[] = [...seasonal, ...funFacts, ...currentEvents];
   if (envDictsPath) {
     try {
-      const extra = JSON.parse(await fs.readFile(envDictsPath, 'utf8')) as WordEntry[];
+      const extraRaw = await fs.readFile(envDictsPath, 'utf8');
+      const extra = parseGen(extraRaw).map((e) => ({
+        answer: e.answer,
+        clue: e.clue,
+        frequency: Infinity,
+      }));
       baseWordList = [...baseWordList, ...extra];
     } catch (e) {
       logError('dict_load_failed', { path: envDictsPath, error: (e as Error).message });


### PR DESCRIPTION
## Summary
- add `parseGen` to parse and sanitize LLM JSON output
- use `parseGen` in `scripts/genDaily.ts` for extra word list parsing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7858569d8832c970fc42704a94275