### PR TITLE
Sort slots by length and crossings

### DIFF
--- a/lib/solver.ts
+++ b/lib/solver.ts
@@ -199,17 +199,10 @@ export function solve(params: SolveParams): SolveResult {
     );
     return [...heroCandidates, ...dictCandidates];
   };
-
-  const candidateCount = (slot: SolverSlot): number =>
-    candidatesFor(getLetters(slot), slot.length).length;
-
   const orderSlots = (all: SolverSlot[]): SolverSlot[] => {
     const sortHeuristics = (arr: SolverSlot[]) =>
       arr.sort((a, b) => {
         if (b.length !== a.length) return b.length - a.length;
-        const ca = candidateCount(a);
-        const cb = candidateCount(b);
-        if (ca !== cb) return ca - cb;
         const ia = intersectionCount.get(a.id) || 0;
         const ib = intersectionCount.get(b.id) || 0;
         return ib - ia;


### PR DESCRIPTION
## Summary
- order fill slots by length and crossing count
- remove candidate-count heuristic for deterministic traversal

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a78a0895f8832cb28994655856432e