### PR TITLE
Add detailed solver logging and expose log utility

### DIFF
--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -15,3 +15,9 @@ export function logWarn(message: string, meta: Record<string, unknown> = {}): vo
 export function logError(message: string, meta: Record<string, unknown> = {}): void {
   console.error(JSON.stringify({ level: 'error', message, ...sanitize(meta) }));
 }
+
+export const log = {
+  info: logInfo,
+  warn: logWarn,
+  error: logError,
+};


### PR DESCRIPTION
## Summary
- export consolidated `log` helper with info/warn/error methods
- add slot attempt, reject, and dead-end logs to solver backtracking
- pipe genDaily logs through new logger interface

## Testing
- `npm test`
- `npm run lint`
- `GENDAILY_TEST=1 npm run gen:daily`

------
https://chatgpt.com/codex/tasks/task_e_68a795bb20a8832c8b5423dece1abb90