### PR TITLE
Add search budget cap and mask rejection reporting

### DIFF
--- a/lib/puzzle.ts
+++ b/lib/puzzle.ts
@@ -396,7 +396,9 @@ export function generateDaily(
         cells,
       };
     } catch (err) {
-      const reason = (err as any).error || (err as Error).message;
+      const message = (err as Error).message;
+      if (message === 'search_budget_exhausted') throw err;
+      const reason = (err as any).error || message;
       logInfo('retry', { attempt: attempt + 1, reason });
       if (attempt === maxMasks - 1) {
         logError('abort', { attempts: attempt + 1, reason });


### PR DESCRIPTION
## Summary
- Track global generation steps and enforce a 2000-step search budget
- Propagate `search_budget_exhausted` errors and report top rejected masks
- Remove obsolete `missing_length` logging

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a798235414832ca08b092621babea6