### PR TITLE
Add answer normalization and candidate filtering tests

### DIFF
--- a/__tests__/getCandidates.test.ts
+++ b/__tests__/getCandidates.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getCandidates } from '../lib/getCandidates';
+import type { WordEntry } from '../lib/puzzle';
+
+const llmJson = JSON.stringify([
+  { answer: 'apple', clue: 'fruit' },
+  { answer: 'alpha', clue: 'first' },
+  { answer: 'agate', clue: 'stone' },
+]);
+
+vi.mock('child_process', () => ({
+  spawnSync: () => ({ status: 0, stdout: llmJson }),
+  default: { spawnSync: () => ({ status: 0, stdout: llmJson }) },
+}));
+
+describe('getCandidates', () => {
+  it('filters candidates by mask including LLM items', () => {
+    const slot = { length: 5 };
+    const pattern = ['A', '', '', '', 'E'];
+    const topical: WordEntry[] = [
+      { answer: 'AGATE', clue: '', frequency: 1 },
+      { answer: 'ALERT', clue: '', frequency: 2 },
+    ];
+    const global: WordEntry[] = [
+      { answer: 'ALARM', clue: '', frequency: 3 },
+    ];
+    process.env.TIER3_URL = 'http://example.com';
+    const res = getCandidates(slot, pattern, topical, global);
+    expect(res.map((c) => c.answer)).toEqual(['AGATE', 'APPLE']);
+    expect(res).toHaveLength(2);
+    delete process.env.TIER3_URL;
+  });
+});

--- a/__tests__/utils/normalizeAnswer.test.ts
+++ b/__tests__/utils/normalizeAnswer.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeAnswer, answerLen } from '../../lib/candidatePool';
+
+describe('normalizeAnswer', () => {
+  it('strips non-letters and uppercases', () => {
+    expect(normalizeAnswer('  spider-man ')).toBe('SPIDERMAN');
+    expect(normalizeAnswer("don't stop" )).toBe('DONTSTOP');
+  });
+});
+
+describe('answerLen', () => {
+  it('computes length after normalization', () => {
+    expect(answerLen(' hi! ')).toBe(2);
+    expect(answerLen('123abc')).toBe(3);
+  });
+});

--- a/lib/getCandidates.ts
+++ b/lib/getCandidates.ts
@@ -62,7 +62,9 @@ export function getCandidates(
     .filter(match)
     .sort((a, b) => (a.frequency ?? Infinity) - (b.frequency ?? Infinity));
   const mask = pattern.map((ch) => ch || ".").join("");
-  const llmCands = queryTier3(mask, len);
+  const llmCands = queryTier3(mask, len)
+    .filter(match)
+    .sort((a, b) => (a.frequency ?? Infinity) - (b.frequency ?? Infinity));
   const seen = new Set<string>();
   const merged: WordEntry[] = [];
   for (const list of [topicalCands, globalCands, llmCands]) {

--- a/tests/integration/fill20250821.test.ts
+++ b/tests/integration/fill20250821.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect, vi } from 'vitest';
+import { solve } from '../../lib/solver';
+import seedrandom from 'seedrandom';
+import { board5x5, slots5x5, dict5x5 } from '../helpers/puzzle5x5';
+
+describe('fill integration 2025-08-21', () => {
+  test('fills grid and logs no missing_length', () => {
+    const board = board5x5.map((row) => [...row]);
+    const slots = slots5x5.map((s) => ({ ...s }));
+    const dict = dict5x5.map((w) => ({ ...w }));
+
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((m: string) => logs.push(m));
+    vi.spyOn(console, 'error').mockImplementation((m: string) => logs.push(m));
+
+    const res = solve({
+      board,
+      slots,
+      dict,
+      heroes: [],
+      rng: seedrandom('2025-08-21'),
+      opts: { maxBranchAttempts: 50, maxTotalAttempts: 20, maxTimeBudgetMs: 1000 },
+    });
+
+    expect(res.ok).toBe(true);
+    expect(board.flat().every((c) => c === '#' || c)).toBe(true);
+
+    const messages = logs
+      .filter((l) => l.startsWith('{'))
+      .map((l) => JSON.parse(l).message);
+    expect(messages).not.toContain('missing_length');
+  });
+});

--- a/tests/lib/candidatePool.test.ts
+++ b/tests/lib/candidatePool.test.ts
@@ -9,18 +9,6 @@ import {
   banlist,
 } from '../../lib/candidatePool';
 
-describe('normalizeAnswer', () => {
-  it('removes non letters and uppercases', () => {
-    expect(normalizeAnswer('  spider-man ')).toBe('SPIDERMAN');
-  });
-});
-
-describe('answerLen', () => {
-  it('computes length after normalization', () => {
-    expect(answerLen(' hi! ')).toBe(2);
-  });
-});
-
 describe('buildCandidatePool', () => {
   it('normalizes, dedupes, assigns frequency and respects banlist', () => {
     const primary = [


### PR DESCRIPTION
## Summary
- add tests for normalizeAnswer and answerLen utilities
- test candidate filtering including regex masks and LLM suggestions
- integration test for 2025-08-21 fill verifying complete grid without missing_length logs
- filter LLM candidates against mask and length

## Testing
- `npx vitest run __tests__/utils/normalizeAnswer.test.ts __tests__/getCandidates.test.ts tests/integration/fill20250821.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a79ae719f8832c8126acac82174be1