### PR TITLE
Add Firestore puzzle listing script

### DIFF
--- a/scripts/listPuzzles.ts
+++ b/scripts/listPuzzles.ts
@@ -1,0 +1,34 @@
+import { Firestore, FieldPath } from '@google-cloud/firestore';
+
+async function main() {
+  const projectId = process.env.FIRESTORE_PROJECT_ID;
+  if (!projectId) {
+    throw new Error('FIRESTORE_PROJECT_ID env var missing');
+  }
+  const firestore = new Firestore({ projectId });
+  const collection = firestore.collection('puzzles');
+
+  const countSnap = await collection.count().get();
+  const total = countSnap.data().count;
+
+  const firstSnap = await collection
+    .orderBy(FieldPath.documentId())
+    .limit(10)
+    .get();
+  const lastSnap = await collection
+    .orderBy(FieldPath.documentId(), 'desc')
+    .limit(10)
+    .get();
+
+  const firstIds = firstSnap.docs.map((doc) => doc.id);
+  const lastIds = lastSnap.docs.map((doc) => doc.id).reverse();
+
+  console.log('Total puzzles:', total);
+  console.log('First 10 IDs:', firstIds.join(', '));
+  console.log('Last 10 IDs:', lastIds.join(', '));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add listPuzzles script to enumerate Firestore puzzles and print basic info

## Testing
- `npm run lint`
- `npm test` *(fails: hung on __tests__/validatePuzzle.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a89a534d18832c82b296d9560ea57e